### PR TITLE
fix: correct jurisdiction metadata from copy-paste template

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -20,14 +20,14 @@ If you are a lawyer, legal researcher, or other legal professional:
 
 - **Malpractice Risk**: Relying on unverified information from this Tool in professional legal work may constitute professional malpractice
 - **Professional Obligations**: You remain solely responsible for verifying all citations, statutes, and legal positions before advising clients or filing documents
-- **Advokatsamfundet Rules**: Swedish Bar Association members must comply with confidentiality rules when using AI tools (see [PRIVACY.md](PRIVACY.md))
+- **Suomen Asianajajaliitto Rules**: Finnish Bar Association members must comply with confidentiality rules when using AI tools (see [PRIVACY.md](PRIVACY.md))
 - **Client Disclosure**: Consider whether professional ethics rules require disclosing AI tool use to clients
 
 ### Duty of Independent Verification
 
 **YOU MUST VERIFY EVERYTHING.** Do not cite, quote, or rely on any provision, case law, or legal interpretation from this Tool without:
 
-1. Checking the official source (Riksdagen, Domstolsverket, or commercial legal databases)
+1. Checking the official source (Finlex, Korkein oikeus, or commercial legal databases)
 2. Verifying the provision is currently in force and has not been amended
 3. Reading the full context of cited provisions
 4. Consulting case law and preparatory works for interpretation
@@ -41,11 +41,11 @@ This Tool aggregates data from multiple sources with varying levels of authority
 
 | Source | Authority Level | Use Case |
 |--------|----------------|----------|
-| **Riksdagen API** | Official government source | Statute text (authoritative) |
+| **Finlex API** | Official government source (Finnish Ministry of Justice) | Statute text (authoritative) |
 | **EUR-Lex** | Official EU legislation database | EU directives/regulations metadata (authoritative) |
-| **Lagen.nu** | Community-maintained (CC-BY Domstolsverket) | Case law (limited coverage, supplementary) |
+| **Korkein oikeus / KKO** | Official court records | Case law (limited coverage, supplementary) |
 
-**CRITICAL**: Lagen.nu is a **community-maintained** resource, NOT an official government publication. While generally reliable, it may contain:
+**CRITICAL**: Community-maintained resources are NOT official government publications. While generally reliable, they may contain:
 
 - Transcription errors
 - Outdated information
@@ -56,10 +56,10 @@ This Tool aggregates data from multiple sources with varying levels of authority
 
 For professional legal work, **always cross-check with commercial legal databases** such as:
 
-- **Karnov** (editorially verified, with annotations and commentary)
-- **Juno** (Norstedts Juridik)
-- **Zeteo** (Wolters Kluwer)
-- **Lagrummet.se** (official government legal information system)
+- **Edilex** (editorially verified, with annotations and commentary)
+- **Suomen Laki** (Talentum/Alma)
+- **Finlex Premium** (Ministry of Justice official service)
+- **Oikeuslaitos.fi** (official Finnish court and justice system portal)
 
 These services provide editorial oversight, comprehensive annotations, and professional-grade currency guarantees that this Tool **cannot** provide.
 
@@ -68,7 +68,7 @@ These services provide editorial oversight, comprehensive annotations, and profe
 ### No Real-Time Updates
 
 - Database updates are **manual** and may lag official publications by **weeks or months**
-- Swedish law changes continuously through new statutes, amendments, and court decisions
+- Finnish law changes continuously through new statutes, amendments, and court decisions
 - **Last-updated timestamps** in tool responses indicate data age, but should be treated as unreliable
 
 ### Staleness Warnings
@@ -106,7 +106,7 @@ These gaps mean:
 
 - **Incomplete Legal Research**: Tool results are inherently incomplete and may miss critical authorities
 - **Context Missing**: Without commentary and preparatory works, interpretation may be incorrect
-- **EU Law Blind Spots**: Cannot assess whether Swedish provision implements EU law or conflicts with CJEU precedent
+- **EU Law Blind Spots**: Cannot assess whether Finnish provision implements EU law or conflicts with CJEU precedent
 
 ## No Warranties
 
@@ -177,20 +177,20 @@ Using this Tool does not reduce your professional obligations to:
 ## Recommended Workflow for Professional Use
 
 1. **Initial Research**: Use Tool for preliminary research and hypothesis generation
-2. **Official Verification**: Cross-check ALL results with official sources (Riksdagen, Domstolsverket)
-3. **Commercial Databases**: Use Karnov, Juno, or Zeteo for authoritative, annotated versions
+2. **Official Verification**: Cross-check ALL results with official sources (Finlex, Oikeuslaitos.fi)
+3. **Commercial Databases**: Use Edilex or Suomen Laki for authoritative, annotated versions
 4. **Professional Judgment**: Apply independent legal analysis and professional judgment
 5. **Document Sources**: Cite official sources in legal work, not this Tool
 6. **Update Check**: Before finalizing legal work, check for recent amendments and decisions
 
 ## Changes to This Disclaimer
 
-This disclaimer may be updated as the Tool evolves or legal/regulatory requirements change. Check the [GitHub repository](https://github.com/Ansvar-Systems/swedish-law-mcp) for the current version.
+This disclaimer may be updated as the Tool evolves or legal/regulatory requirements change. Check the [GitHub repository](https://github.com/Ansvar-Systems/finnish-law-mcp) for the current version.
 
 ## Questions?
 
 For questions about this disclaimer or the Tool's limitations, please open an issue on GitHub:
-https://github.com/Ansvar-Systems/swedish-law-mcp/issues
+https://github.com/Ansvar-Systems/finnish-law-mcp/issues
 
 ---
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 **CRITICAL READING FOR LEGAL PROFESSIONALS**
 
-This document addresses privacy and confidentiality considerations when using this Tool, with particular attention to professional obligations under Swedish Bar Association (Advokatsamfundet) rules.
+This document addresses privacy and confidentiality considerations when using this Tool, with particular attention to professional obligations under Finnish Bar Association (Suomen Asianajajaliitto) rules.
 
 ---
 
@@ -11,7 +11,7 @@ This document addresses privacy and confidentiality considerations when using th
 ⚠️ **Key Risks:**
 - Queries flow through Claude API infrastructure (Anthropic cloud)
 - Query content may reveal client matters and privileged information
-- Swedish Bar Association rules require strict data processing controls
+- Finnish Bar Association (Suomen Asianajajaliitto) rules require strict data processing controls
 
 ✅ **Safe Use Options:**
 1. **General Legal Research**: Use Tool for non-client-specific queries
@@ -55,9 +55,9 @@ When you use this Tool through Claude Desktop or API:
 
 ## Legal Professional Obligations
 
-### Advokatsamfundet (Swedish Bar Association) Rules
+### Suomen Asianajajaliitto (Finnish Bar Association) Rules
 
-Swedish lawyers are bound by **strict confidentiality rules** under the Advocates Act (Rättegångsbalken 8:4) and Advokatsamfundet's Code of Conduct.
+Finnish lawyers are bound by **strict confidentiality rules** under the Advocates Act (Laki asianajajista 496/1958) and Suomen Asianajajaliitto's Code of Conduct.
 
 #### Tystnadsplikt (Duty of Confidentiality)
 
@@ -96,7 +96,7 @@ Under **GDPR Article 28**, when you use a service that processes client data:
 **Safe to use through Claude API:**
 
 ```
-Example Query: "What does Swedish GDPR implementation say about data breach notification?"
+Example Query: "What does Finnish GDPR implementation say about data breach notification?"
 ```
 
 - No client identity
@@ -109,7 +109,7 @@ Example Query: "What does Swedish GDPR implementation say about data breach noti
 **Use with caution:**
 
 ```
-Example Query: "What are the penalties under Swedish criminal law for insider trading?"
+Example Query: "What are the penalties under Finnish criminal law for insider trading?"
 ```
 
 **Risks:**
@@ -134,7 +134,7 @@ Bad Example: "Find precedents for custody disputes involving allegations of subs
 - Geographic specificity
 - Case-specific facts
 - May reveal client identity or confidential strategy
-- May violate Advokatsamfundet rules even if client name not mentioned
+- May violate Suomen Asianajajaliitto rules even if client name not mentioned
 
 **What to do instead:**
 - Use Karnov, Juno, or other commercial legal databases with DPAs
@@ -156,7 +156,7 @@ User Query → Local MCP Client → Local LLM (no external API) → MCP Server (
 **Benefits:**
 - No query data sent to Anthropic or any external service
 - Full control over logging and data retention
-- Compliant with Advokatsamfundet confidentiality rules
+- Compliant with Suomen Asianajajaliitto confidentiality rules
 - GDPR-compliant (no third-party processors)
 
 ### Self-Hosted LLM Options
@@ -192,9 +192,9 @@ For acceptable performance with a 70B parameter model (Llama 3.1 70B or similar)
    ```json
    {
      "mcpServers": {
-       "swedish-law": {
+       "finnish-law": {
          "command": "npx",
-         "args": ["-y", "@ansvar/swedish-law-mcp"],
+         "args": ["-y", "@ansvar/finnish-law-mcp"],
          "env": {
            "ANTHROPIC_API_KEY": "local",
            "LOCAL_LLM": "ollama",
@@ -303,7 +303,7 @@ Some jurisdictions require disclosing AI tool use in legal work:
 - **To Clients**: Best practice even if not strictly required
 - **To Opposing Counsel**: Generally not required unless court rules mandate
 
-**Sweden**: No specific disclosure requirement yet, but professional ethics (god advokatsed) may require transparency with clients.
+**Finland**: No specific disclosure requirement yet, but professional ethics (hyvä asianajajatapa) may require transparency with clients.
 
 ---
 
@@ -350,8 +350,8 @@ Some jurisdictions require disclosing AI tool use in legal work:
 For questions about privacy and confidentiality:
 
 1. **Anthropic Privacy**: Contact privacy@anthropic.com
-2. **Advokatsamfundet Guidance**: Consult Swedish Bar Association ethics hotline
-3. **Tool-Specific**: Open issue on [GitHub](https://github.com/Ansvar-Systems/swedish-law-mcp/issues)
+2. **Suomen Asianajajaliitto Guidance**: Consult Finnish Bar Association ethics helpline
+3. **Tool-Specific**: Open issue on [GitHub](https://github.com/Ansvar-Systems/finnish-law-mcp/issues)
 
 ### Incident Reporting
 
@@ -360,8 +360,8 @@ If you suspect a confidentiality breach (e.g., accidentally queried client name)
 1. **Document Incident**: Record what information was transmitted and when
 2. **Notify Client**: Inform affected client under GDPR breach notification rules
 3. **Contact Anthropic**: Request deletion of query logs (if possible)
-4. **Advokatsamfundet**: Report to Bar Association if required
-5. **GDPR Authority**: Report to Integritetsskyddsmyndigheten if personal data breach
+4. **Suomen Asianajajaliitto**: Report to Finnish Bar Association if required
+5. **GDPR Authority**: Report to Tietosuojavaltuutettu (Finnish Data Protection Ombudsman) if personal data breach
 
 ---
 
@@ -372,7 +372,7 @@ This privacy notice may be updated as:
 - New professional ethics guidance emerges
 - Tool deployment options expand
 
-Check [GitHub repository](https://github.com/Ansvar-Systems/swedish-law-mcp) for current version.
+Check [GitHub repository](https://github.com/Ansvar-Systems/finnish-law-mcp) for current version.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# Swedish Law MCP Server
+# Finnish Law MCP Server
 
-**The Riksdagen alternative for the AI age.**
+**The Finlex alternative for the AI age.**
 
-[![npm version](https://badge.fury.io/js/@ansvar%2Fswedish-law-mcp.svg)](https://www.npmjs.com/package/@ansvar/swedish-law-mcp)
+[![npm version](https://badge.fury.io/js/@ansvar%2Ffinnish-law-mcp.svg)](https://www.npmjs.com/package/@ansvar/finnish-law-mcp)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue)](https://registry.modelcontextprotocol.io)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![GitHub stars](https://img.shields.io/github/stars/Ansvar-Systems/swedish-law-mcp?style=social)](https://github.com/Ansvar-Systems/swedish-law-mcp)
-[![CI](https://github.com/Ansvar-Systems/swedish-law-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Ansvar-Systems/swedish-law-mcp/actions/workflows/ci.yml)
-[![Daily Data Check](https://github.com/Ansvar-Systems/swedish-law-mcp/actions/workflows/check-updates.yml/badge.svg)](https://github.com/Ansvar-Systems/swedish-law-mcp/actions/workflows/check-updates.yml)
+[![GitHub stars](https://img.shields.io/github/stars/Ansvar-Systems/finnish-law-mcp?style=social)](https://github.com/Ansvar-Systems/finnish-law-mcp)
+[![CI](https://github.com/Ansvar-Systems/finnish-law-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Ansvar-Systems/finnish-law-mcp/actions/workflows/ci.yml)
+[![Daily Data Check](https://github.com/Ansvar-Systems/finnish-law-mcp/actions/workflows/check-updates.yml/badge.svg)](https://github.com/Ansvar-Systems/finnish-law-mcp/actions/workflows/check-updates.yml)
 [![Database](https://img.shields.io/badge/database-pre--built-green)](docs/EU_INTEGRATION_GUIDE.md)
 [![Provisions](https://img.shields.io/badge/provisions-31%2C198-blue)](docs/EU_INTEGRATION_GUIDE.md)
 
-Query **717 Swedish statutes** -- from Dataskyddslagen and Brottsbalken to Aktiebolagslagen, Miljöbalken, and more -- directly from Claude, Cursor, or any MCP-compatible client.
+Query **Finnish statutes** -- from Tietosuojalaki and Rikoslaki to Osakeyhtiölaki, Ympäristönsuojelulaki, and more -- directly from Claude, Cursor, or any MCP-compatible client.
 
-If you're building legal tech, compliance tools, or doing Swedish legal research, this is your verified reference database.
+If you're building legal tech, compliance tools, or doing Finnish legal research, this is your verified reference database.
 
-Built by [Ansvar Systems](https://ansvar.eu) -- Stockholm, Sweden
+Built by [Ansvar Systems](https://ansvar.eu) -- Helsinki, Finland
 
 ---
 


### PR DESCRIPTION
## Summary
Squash of fix/correct-jurisdiction-metadata into dev, now promoting to main.

README.md, DISCLAIMER.md, PRIVACY.md were copy-pasted from Swedish Law MCP. metadata.ts and sources.yml were already correctly Finnish.

- README: "Swedish Law MCP Server" → "Finnish Law MCP Server", all links corrected
- DISCLAIMER: Advokatsamfundet → Suomen Asianajajaliitto, Riksdagen/Domstolsverket → Finlex/Korkein oikeus, Swedish commercial DB refs → Finnish equivalents
- PRIVACY: all Swedish Bar/Advokatsamfundet refs → Finnish Bar/Suomen Asianajajaliitto, Integritetsskyddsmyndigheten → Tietosuojavaltuutettu, god advokatsed → hyvä asianajajatapa

## Test plan
- [ ] `npm run lint` passes
- [ ] README title reads "Finnish Law MCP Server"
- [ ] DISCLAIMER references Finlex and Suomen Asianajajaliitto
- [ ] PRIVACY references Tietosuojavaltuutettu

🤖 Generated with [Claude Code](https://claude.com/claude-code)