### PR TITLE
feat: add check_data_freshness meta-tool (Phase D D.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ data/eu-references-analysis.json
 # CLAUDE / AGENT WORK
 # ───────────────────────────────────────────────────────────────────────────
 .claude/
+.worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 
 COPY --from=builder --chown=nodejs:nodejs /app/dist ./dist
 COPY --chown=nodejs:nodejs data/database.db ./data/database.db
+COPY --chown=nodejs:nodejs sources.yml ./sources.yml
 
 # Ensure /app/data exists and is writable by the runtime user.
 # SQLite needs to write -wal/-shm sidecars in the DB directory.

--- a/manifest.json
+++ b/manifest.json
@@ -53,7 +53,8 @@
     { "name": "validate_eu_compliance" },
     { "name": "about" },
     { "name": "list_sources" },
-    { "name": "get_provision_at_date" }
+    { "name": "get_provision_at_date" },
+    { "name": "check_data_freshness" }
   ],
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ansvar/mcp-sqlite": "^1.0.3",
-        "@modelcontextprotocol/sdk": "^1.25.3"
+        "@modelcontextprotocol/sdk": "^1.25.3",
+        "js-yaml": "^4.1.1"
       },
       "bin": {
         "finnish-law-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
+        "@types/js-yaml": "^4.0.9",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.15.29",
         "@vitest/coverage-v8": "^4.0.18",
@@ -1237,6 +1239,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
@@ -1463,6 +1472,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2581,6 +2596,18 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "27.4.0",

--- a/package.json
+++ b/package.json
@@ -50,10 +50,12 @@
   },
   "dependencies": {
     "@ansvar/mcp-sqlite": "^1.0.3",
-    "@modelcontextprotocol/sdk": "^1.25.3"
+    "@modelcontextprotocol/sdk": "^1.25.3",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
+    "@types/js-yaml": "^4.0.9",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.15.29",
     "@vitest/coverage-v8": "^4.0.18",

--- a/sources.yml
+++ b/sources.yml
@@ -11,6 +11,7 @@ sources:
     api_documentation: 'https://finlex.fi/fi/api/'
     update_frequency: 'daily'
     last_ingested: '2026-02-14'
+    last_verified: '2026-05-09'
     license_or_terms:
       type: 'Government Open Data (CC BY 4.0)'
       url: 'https://finlex.fi/fi/oikeuslaitos/tietoa-finlexista/'
@@ -29,6 +30,7 @@ sources:
     api_documentation: 'https://eur-lex.europa.eu/content/tools/webservices/SearchWebServiceUserManual_v2.00.pdf'
     update_frequency: 'as needed'
     last_ingested: '2026-02-14'
+    last_verified: '2026-05-09'
     license_or_terms:
       type: 'EU public domain'
       url: 'https://eur-lex.europa.eu/content/legal-notice/legal-notice.html'

--- a/src/tools/check-data-freshness.ts
+++ b/src/tools/check-data-freshness.ts
@@ -1,0 +1,93 @@
+/**
+ * check_data_freshness — mandatory meta-tool per law-mcp-golden-standard §4.1.
+ *
+ * Returns the corpus build timestamp and per-source last_verified dates with
+ * staleness_days computed against a configurable threshold (default 90 days).
+ * The watchdog probes this tool to alert on stale data; consumers call it to
+ * verify the corpus is current before acting on results.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import yaml from 'js-yaml';
+import type Database from '@ansvar/mcp-sqlite';
+import { readDbMetadata } from '../capabilities.js';
+
+const DEFAULT_STALENESS_THRESHOLD_DAYS = 90;
+const UNKNOWN_STALENESS_DAYS = 999;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}/;
+const MS_PER_DAY = 86_400_000;
+
+export interface SourceFreshness {
+  publisher: string;
+  source_url: string;
+  last_verified: string;
+  staleness_days: number;
+}
+
+export interface CheckDataFreshnessResult {
+  build_timestamp: string;
+  sources: SourceFreshness[];
+  has_stale_sources: boolean;
+  staleness_threshold_days: number;
+}
+
+export interface CheckDataFreshnessOptions {
+  /** Path to sources.yml. Defaults to `<cwd>/sources.yml`. */
+  sourcesYmlPath?: string;
+  /** Days past `last_verified` before a source is considered stale. */
+  thresholdDays?: number;
+  /** Reference time for staleness computation. Defaults to `new Date()`. */
+  now?: Date;
+}
+
+interface SourceEntry {
+  name?: string;
+  authority?: string;
+  official_portal?: string;
+  last_verified?: string;
+}
+
+interface SourcesYml {
+  sources?: SourceEntry[];
+}
+
+function computeStaleness(lastVerified: string | undefined, nowMs: number): number {
+  if (!lastVerified || !ISO_DATE.test(lastVerified)) {
+    return UNKNOWN_STALENESS_DAYS;
+  }
+  const parsed = Date.parse(lastVerified);
+  if (Number.isNaN(parsed)) {
+    return UNKNOWN_STALENESS_DAYS;
+  }
+  return Math.floor((nowMs - parsed) / MS_PER_DAY);
+}
+
+export function checkDataFreshness(
+  db: InstanceType<typeof Database>,
+  options: CheckDataFreshnessOptions = {},
+): CheckDataFreshnessResult {
+  const thresholdDays = options.thresholdDays ?? DEFAULT_STALENESS_THRESHOLD_DAYS;
+  const nowMs = (options.now ?? new Date()).getTime();
+  const sourcesYmlPath = options.sourcesYmlPath ?? resolve(process.cwd(), 'sources.yml');
+
+  const meta = readDbMetadata(db);
+  const buildTimestamp = meta.built_at;
+
+  const yml = (yaml.load(readFileSync(sourcesYmlPath, 'utf8')) ?? {}) as SourcesYml;
+  const entries = yml.sources ?? [];
+
+  const sources: SourceFreshness[] = entries.map((s) => ({
+    publisher: s.authority ?? s.name ?? 'unknown',
+    source_url: s.official_portal ?? '',
+    last_verified: s.last_verified ?? 'unknown',
+    staleness_days: computeStaleness(s.last_verified, nowMs),
+  }));
+
+  return {
+    build_timestamp: buildTimestamp,
+    sources,
+    has_stale_sources: sources.some((s) => s.staleness_days > thresholdDays),
+    staleness_threshold_days: thresholdDays,
+  };
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -26,6 +26,7 @@ import { getProvisionEUBasis, GetProvisionEUBasisInput } from './get-provision-e
 import { validateEUCompliance, ValidateEUComplianceInput } from './validate-eu-compliance.js';
 import { getAbout, type AboutContext } from './about.js';
 import { listSources } from './list-sources.js';
+import { checkDataFreshness } from './check-data-freshness.js';
 import { getProvisionAtDate, GetProvisionAtDateParams, toolDefinition as provisionAtDateDef } from './get-provision-at-date.js';
 export type { AboutContext } from './about.js';
 
@@ -256,6 +257,17 @@ When NOT to use: For basic EU reference lookup, use get_eu_basis. This tool asse
       properties: {},
     },
   },
+  {
+    name: 'check_data_freshness',
+    description:
+      'Returns the corpus build timestamp and per-source last_verified dates with staleness_days against a 90-day threshold. ' +
+      'Use this to verify whether the data backing this MCP is current before relying on it for compliance work. ' +
+      'For full source provenance, use list_sources; for server statistics, use about.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
   provisionAtDateDef as Tool,
 ];
 
@@ -325,6 +337,9 @@ export function registerTools(
           break;
         case 'list_sources':
           result = listSources();
+          break;
+        case 'check_data_freshness':
+          result = checkDataFreshness(db);
           break;
         case 'get_provision_at_date':
           result = getProvisionAtDate(db, args as unknown as GetProvisionAtDateParams);

--- a/tests/check-data-freshness.test.ts
+++ b/tests/check-data-freshness.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import Database from '@ansvar/mcp-sqlite';
+import { checkDataFreshness } from '../src/tools/check-data-freshness.js';
+
+function addMetadata(db: InstanceType<typeof Database>, entries: Record<string, string>): void {
+  db.prepare(
+    `CREATE TABLE IF NOT EXISTS db_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+  ).run();
+  const insert = db.prepare('INSERT INTO db_metadata (key, value) VALUES (?, ?)');
+  for (const [k, v] of Object.entries(entries)) {
+    insert.run(k, v);
+  }
+}
+
+describe('check_data_freshness', () => {
+  let db: InstanceType<typeof Database>;
+  let tmp: string;
+  let sourcesPath: string;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    tmp = mkdtempSync(join(tmpdir(), 'cdf-test-'));
+    sourcesPath = join(tmp, 'sources.yml');
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns build_timestamp and per-source last_verified with staleness_days', () => {
+    addMetadata(db, { built_at: '2026-05-02T10:00:00.000Z' });
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "Lovdata API"
+    authority: "Stiftelsen Lovdata"
+    official_portal: "https://api.lovdata.no/"
+    last_verified: "2026-05-09"
+`,
+    );
+    const now = new Date('2026-05-09T12:00:00.000Z');
+
+    const result = checkDataFreshness(db, { sourcesYmlPath: sourcesPath, now });
+
+    expect(result.build_timestamp).toBe('2026-05-02T10:00:00.000Z');
+    expect(result.sources).toHaveLength(1);
+    expect(result.sources[0].publisher).toBe('Stiftelsen Lovdata');
+    expect(result.sources[0].source_url).toBe('https://api.lovdata.no/');
+    expect(result.sources[0].last_verified).toBe('2026-05-09');
+    expect(result.sources[0].staleness_days).toBe(0);
+    expect(result.has_stale_sources).toBe(false);
+    expect(result.staleness_threshold_days).toBe(90);
+  });
+
+  it('flags has_stale_sources when any source is past the 90-day threshold', () => {
+    addMetadata(db, { built_at: '2026-01-01T00:00:00.000Z' });
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "Recent source"
+    authority: "Recent"
+    last_verified: "2026-04-15"
+  - name: "Stale source"
+    authority: "Stale"
+    last_verified: "2026-01-15"
+`,
+    );
+    const now = new Date('2026-05-09T00:00:00.000Z');
+
+    const result = checkDataFreshness(db, { sourcesYmlPath: sourcesPath, now });
+
+    expect(result.sources).toHaveLength(2);
+    const recent = result.sources.find((s) => s.publisher === 'Recent')!;
+    const stale = result.sources.find((s) => s.publisher === 'Stale')!;
+    expect(recent.staleness_days).toBeLessThanOrEqual(90);
+    expect(stale.staleness_days).toBeGreaterThan(90);
+    expect(result.has_stale_sources).toBe(true);
+  });
+
+  it('returns staleness_days=999 when last_verified is missing or non-ISO', () => {
+    addMetadata(db, { built_at: '2026-05-02T10:00:00.000Z' });
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "No date"
+    authority: "Missing"
+  - name: "Bad date"
+    authority: "Invalid"
+    last_verified: "TBD"
+`,
+    );
+
+    const result = checkDataFreshness(db, { sourcesYmlPath: sourcesPath });
+
+    expect(result.sources[0].staleness_days).toBe(999);
+    expect(result.sources[1].staleness_days).toBe(999);
+    expect(result.has_stale_sources).toBe(true);
+  });
+
+  it('returns build_timestamp="unknown" when db_metadata is missing', () => {
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "X"
+    authority: "Y"
+    last_verified: "2026-05-09"
+`,
+    );
+    const now = new Date('2026-05-09T00:00:00.000Z');
+
+    const result = checkDataFreshness(db, { sourcesYmlPath: sourcesPath, now });
+
+    expect(result.build_timestamp).toBe('unknown');
+  });
+
+  it('honours a custom thresholdDays option', () => {
+    addMetadata(db, { built_at: '2026-05-02T10:00:00.000Z' });
+    writeFileSync(
+      sourcesPath,
+      `sources:
+  - name: "Daily source"
+    authority: "Court feed"
+    last_verified: "2026-05-01"
+`,
+    );
+    const now = new Date('2026-05-09T00:00:00.000Z');
+
+    const result = checkDataFreshness(db, {
+      sourcesYmlPath: sourcesPath,
+      thresholdDays: 7,
+      now,
+    });
+
+    expect(result.staleness_threshold_days).toBe(7);
+    expect(result.sources[0].staleness_days).toBe(8);
+    expect(result.has_stale_sources).toBe(true);
+  });
+});


### PR DESCRIPTION
Phase D D.4 — adds check_data_freshness meta-tool per law-mcp-golden-standard §4.1. Templates from D.1 reference (Norwegian-law-mcp #61 + #62).

Three changes per the post-D.1 recipe:
- src/tools/check-data-freshness.ts + tests/check-data-freshness.test.ts (5 specs) — verbatim from D.1.
- sources.yml — added `last_verified: '2026-05-09'` to Finlex + EUR-Lex sources.
- Dockerfile — COPY sources.yml ./sources.yml in runtime stage.

Note on shape: this repo embeds list_sources inline in the TOOLS array (not as a separate const like Norwegian/Swedish/Icelandic). New tool definition follows the same inline convention.

Verification: lint + build clean, 167 tests pass / 31 skipped, 5 new specs pass. Post-merge: prod recreate per Phase B+C close-out (all 3 -f compose files).

Plan: docs/superpowers/plans/2026-05-09-nordic-golden-standard-rollout.md (Phase D Task D.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)