### PR TITLE
docs(readme): Gateway-first CTA + honest self-host section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,54 @@
 # Finnish Law MCP Server
 
+<!-- ANSVAR-CTA-BEGIN -->
+> ### ▶ Try this MCP instantly via Ansvar Gateway
+> **50 free queries/day · no card required · OAuth signup at [ansvar.eu/gateway](https://ansvar.eu/gateway)**
+>
+> One endpoint, one OAuth signup, access from any MCP-compatible client.
+
+### Connect
+
+**Claude Code** (one line):
+
+```bash
+claude mcp add ansvar --transport http https://gateway.ansvar.eu/mcp
+```
+
+**Claude Desktop / Cursor** — add to `claude_desktop_config.json` (or `mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "ansvar": {
+      "type": "url",
+      "url": "https://gateway.ansvar.eu/mcp"
+    }
+  }
+}
+```
+
+**Claude.ai** — Settings → Connectors → Add custom connector → paste `https://gateway.ansvar.eu/mcp`
+
+First request opens an OAuth flow at [ansvar.eu/gateway](https://ansvar.eu/gateway). After signup, your client is bound to your account; tier (free / premium / team / company) determines fan-out, quota, and which downstream MCPs are reachable.
+
+---
+
+## Self-host this MCP
+
+You can also clone this repo and build the corpus yourself. The schema,
+fetcher, and tool implementations all live here. What is not in the repo is
+the pre-built database — TDM and standards-licensing constraints on the
+upstream sources mean we host the corpus on Ansvar infrastructure rather
+than redistribute it as a public artifact.
+
+Build your own: run this repo's ingestion script (entry-point varies per
+repo — typically `scripts/ingest.sh`, `npm run ingest`, or `make ingest`;
+check the repo root).
+<!-- ANSVAR-CTA-END -->
+
+
 **The Finlex alternative for the AI age.**
 
-[![npm version](https://badge.fury.io/js/@ansvar%2Ffinnish-law-mcp.svg)](https://www.npmjs.com/package/@ansvar/finnish-law-mcp)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue)](https://registry.modelcontextprotocol.io)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![GitHub stars](https://img.shields.io/github/stars/Ansvar-Systems/finnish-law-mcp?style=social)](https://github.com/Ansvar-Systems/finnish-law-mcp)
@@ -32,82 +78,6 @@ Swedish legal research is scattered across Riksdagen, SFS publications, lagen.nu
 This MCP server makes Swedish law **searchable, cross-referenceable, and AI-readable**.
 
 ---
-
-## Quick Start
-
-### Use Remotely (No Install Needed)
-
-> Connect directly to the hosted version — zero dependencies, nothing to install.
-
-**Endpoint:** `https://mcp.ansvar.eu/law-fi/mcp`
-
-| Client | How to Connect |
-|--------|---------------|
-| **Claude.ai** | Settings > Connectors > Add Integration > paste URL |
-| **Claude Code** | `claude mcp add swedish-law --transport http https://mcp.ansvar.eu/law-fi/mcp` |
-| **Claude Desktop** | Add to config (see below) |
-| **GitHub Copilot** | Add to VS Code settings (see below) |
-
-**Claude Desktop** — add to `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "swedish-law": {
-      "type": "url",
-      "url": "https://mcp.ansvar.eu/law-fi/mcp"
-    }
-  }
-}
-```
-
-**GitHub Copilot** — add to VS Code `settings.json`:
-
-```json
-{
-  "github.copilot.chat.mcp.servers": {
-    "swedish-law": {
-      "type": "http",
-      "url": "https://mcp.ansvar.eu/law-fi/mcp"
-    }
-  }
-}
-```
-
-### Use Locally (npm)
-
-```bash
-npx @ansvar/swedish-law-mcp
-```
-
-**Claude Desktop** — add to `claude_desktop_config.json`:
-
-**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
-**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "swedish-law": {
-      "command": "npx",
-      "args": ["-y", "@ansvar/swedish-law-mcp"]
-    }
-  }
-}
-```
-
-**Cursor / VS Code:**
-
-```json
-{
-  "mcp.servers": {
-    "swedish-law": {
-      "command": "npx",
-      "args": ["-y", "@ansvar/swedish-law-mcp"]
-    }
-  }
-}
-```
 
 ## Example Queries
 
@@ -345,30 +315,9 @@ npm run check-updates                          # Check for amendments
 
 ---
 
-## Related Projects: Complete Compliance Suite
+## More Ansvar MCPs
 
-This server is part of **Ansvar's Compliance Suite** -- MCP servers that work together for end-to-end compliance coverage:
-
-### [@ansvar/eu-regulations-mcp](https://github.com/Ansvar-Systems/EU_compliance_MCP)
-**Query 49 EU regulations directly from Claude** -- GDPR, AI Act, DORA, NIS2, MiFID II, eIDAS, and more. Full regulatory text with article-level search. `npx @ansvar/eu-regulations-mcp`
-
-### @ansvar/swedish-law-mcp (This Project)
-**Query 717 Swedish statutes directly from Claude** -- DSL, BrB, ABL, MB, and more. Full provision text with EU cross-references. `npx @ansvar/swedish-law-mcp`
-
-### [@ansvar/us-regulations-mcp](https://github.com/Ansvar-Systems/US_Compliance_MCP)
-**Query US federal and state compliance laws** -- HIPAA, CCPA, SOX, GLBA, FERPA, and more. `npm install @ansvar/us-regulations-mcp`
-
-### [@ansvar/ot-security-mcp](https://github.com/Ansvar-Systems/ot-security-mcp)
-**Query IEC 62443, NIST 800-82/53, and MITRE ATT&CK for ICS** -- Specialized for OT/ICS environments. `npx @ansvar/ot-security-mcp`
-
-### [@ansvar/automotive-cybersecurity-mcp](https://github.com/Ansvar-Systems/Automotive-MCP)
-**Query UNECE R155/R156 and ISO 21434** -- Automotive cybersecurity compliance. `npx @ansvar/automotive-cybersecurity-mcp`
-
-### [@ansvar/sanctions-mcp](https://github.com/Ansvar-Systems/Sanctions-MCP)
-**Offline-capable sanctions screening** -- OFAC, EU, UN sanctions lists. `pip install ansvar-sanctions-mcp`
-
----
-
+Full fleet at [ansvar.eu/gateway](https://ansvar.eu/gateway).
 ## Contributing
 
 Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
@@ -386,7 +335,6 @@ Priority areas:
 - [x] **Statute expansion** -- 785% growth from 81 to 717 statutes (v1.1.0)
 - [x] **EU law integration** -- 668 cross-references to 228 EU directives/regulations (v1.1.0)
 - [ ] Court case law expansion (scraper updated, re-ingestion needed for 12K-18K cases)
-- [ ] Full EU text integration (via @ansvar/eu-regulations-mcp)
 - [ ] Lower court coverage (Tingsrätt, Hovrätt archives)
 - [ ] Historical statute versions (amendment tracking)
 - [ ] English translations for key statutes


### PR DESCRIPTION
## Gateway-first README

This PR rewrites the README to:

1. Lead with the Ansvar Gateway free-tier CTA above the fold (50 queries/day, no card required, OAuth from Claude Desktop / Cursor / Copilot).
2. Strip dead ingress paths: `mcp.ansvar.eu/*` URLs (decommissioned 2026-04-23) and `@ansvar/*` npm package references (decommissioned 2026-05-05 — see [ADR-021 Superseded](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/adr/ADR-021-npm-distribution-strategy.md)).
3. Replace the sibling-MCP "Other Ansvar MCPs" gallery (which advertised dead npm packages) with a single Gateway link.

Everything below the CTA block is preserved verbatim: tool schemas, capabilities, examples, contributing guide.

The change is idempotent (CTA block lives between `<!-- ANSVAR-CTA-BEGIN -->` / `<!-- ANSVAR-CTA-END -->` markers).

Spec: [`2026-05-17-public-mcp-readme-gateway-cta-rollout-design.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/superpowers/specs/2026-05-17-public-mcp-readme-gateway-cta-rollout-design.md).
Rollout runbook: [`mcp-readme-rollout.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/runbooks/mcp-readme-rollout.md).
