### PR TITLE
chore: sync license to FI-Statutory-PD per arch-docs 2026-05-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,9 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Statutes & Propositions:** Swedish Government (public domain)
-- **Case Law:** CC-BY Domstolsverket (via lagen.nu)
-- **EU Metadata:** EUR-Lex (EU public domain)
+- **Statutes & Decrees:** `FI-Statutory-PD` — Finnish statutory public domain. Tekijänoikeuslaki 9 § (404/1961 as amended by 608/2015) excludes laws and decrees, decisions and statements of public authorities, and authority-produced translations of these works from copyright protection. Verified verbatim 2026-05-17 — see [`docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md). Catalog entry: `FI-Statutory-PD` in `infrastructure/attribution-licenses.json`.
+- **Case Law:** Finnish court decisions — same statutory basis (Tekijänoikeuslaki 9 § public-authority-decisions clause)
+- **EU Metadata:** EUR-Lex (EU public domain, Decision 2011/833/EU)
 
 ---
 

--- a/sources.yml
+++ b/sources.yml
@@ -1,3 +1,13 @@
+# sources.yml — Data provenance metadata
+# License axis: FI-Statutory-PD (Finnish statutory public domain)
+# Statutory basis: Tekijänoikeuslaki 9 § (404/1961, as amended by 608/2015) —
+# laws and decrees, decisions and statements of public authorities, and
+# translations of these works produced by or commissioned by public
+# authorities are excluded from copyright protection.
+# Verified verbatim 2026-05-17.
+# Cross-ref: docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md
+# Catalog entry: infrastructure/attribution-licenses.json → "FI-Statutory-PD"
+
 schema_version: '1.0'
 mcp_name: 'Finnish Law MCP'
 jurisdiction: 'FI'
@@ -13,9 +23,9 @@ sources:
     last_ingested: '2026-02-14'
     last_verified: '2026-05-09'
     license_or_terms:
-      type: 'Government Open Data (CC BY 4.0)'
-      url: 'https://finlex.fi/fi/oikeuslaitos/tietoa-finlexista/'
-      summary: 'Finnish government open data, free to use with attribution'
+      type: 'FI-Statutory-PD'
+      url: 'https://finlex.fi/fi/lainsaadanto/1961/404'
+      summary: 'Finnish statutory public domain (Tekijänoikeuslaki 9 §, 404/1961 as amended by 608/2015). Laws and decrees, decisions and statements of public authorities, and authority-produced translations of these works are excluded from copyright protection. Statute-level basis on the underlying text; Finlex compilation is additionally redistributable under government open-data terms.'
     coverage:
       scope: 'Finnish statutes and regulations'
       limitations: 'Historical versions depend on Finlex coverage'


### PR DESCRIPTION
## Summary

Replace generic license declaration with the jurisdiction-specific statutory-PD code that landed in arch-docs catalog today.

- `sources.yml` license type updated to `FI-Statutory-PD`
- README data-licenses block points at the statutory section and the new catalog entry

## Statutory basis

Tekijänoikeuslaki 9 § (404/1961 as amended by 608/2015) — laws and decrees, decisions and statements of public authorities, and authority-produced translations excluded from copyright protection. Verified verbatim 2026-05-17.

## Scope

License-axis sync only. No corpus content, ingestion code, or runtime behaviour changes.

## Cross-references

- `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md` (arch-docs)
- `infrastructure/attribution-licenses.json` → `FI-Statutory-PD` (arch-docs)

## Test plan

- [ ] CI green (7 workflows + tests)
- [ ] No diff in `data/` or `src/` (license-axis only)