### PR TITLE
fix(deps): bump @ansvar/mcp-sqlite to ^1.0.5 — close WASM lock crashloop trap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ansvar/mcp-sqlite": "^1.0.3",
+        "@ansvar/mcp-sqlite": "^1.0.5",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "js-yaml": "^4.1.1"
       },
@@ -42,9 +42,9 @@
       "license": "MIT"
     },
     "node_modules/@ansvar/mcp-sqlite": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@ansvar/mcp-sqlite/-/mcp-sqlite-1.0.3.tgz",
-      "integrity": "sha512-e4kS/84VOUU9YBAU+ls9KhouVA9gPHZAcuHjxTZP9ZyCnknlkOEI9yzYGnsNQdDT3a6d+rvDNPdu1dgaUtH5yg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@ansvar/mcp-sqlite/-/mcp-sqlite-1.0.5.tgz",
+      "integrity": "sha512-RsdxHZhLzyQkpPGQJ2w59O7m/aHtRYHa5ymThI+mJykAnb+qjCJClBK+E/bo40miUhyXqz4VFe0MztOYQgfJRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "node-sqlite3-wasm": "^0.8.53"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ingest:full": "npm run ingest:fetch && npm run build:db && npm run coverage:update"
   },
   "dependencies": {
-    "@ansvar/mcp-sqlite": "^1.0.3",
+    "@ansvar/mcp-sqlite": "^1.0.5",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "js-yaml": "^4.1.1"
   },


### PR DESCRIPTION
## Summary

Pre-emptive bump. Same shape as croatian-law-mcp [#85](https://github.com/Ansvar-Systems/Croatian-law-mcp/pull/85)/[#86](https://github.com/Ansvar-Systems/Croatian-law-mcp/pull/86) and international-privacy-law-mcp [#51](https://github.com/Ansvar-Systems/international-privacy-law-mcp/pull/51).

`@ansvar/mcp-sqlite ^1.0.3` (resolves 1.0.3) → `^1.0.5`. v1.0.5 clears stale `.lock/` directories in the `Database()` constructor, preventing the docker-overlay-FS crashloop class.

## Why now

This MCP became gateway-live on 2026-05-28 via arch-docs [PR #952](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/pull/952) — a fleet-wide audit found Finland's chassis container had a stale 19MB seed vs the standalone's 169MB, so gateway routing was re-pointed at this standalone. With live traffic now flowing here, the dormant WASM trap becomes a real outage risk: one uncontrolled crash + `docker restart` and the container is stuck permanently.

## Verification

- `npm test`: 167 passed, 31 skipped (pre-existing)
- `npm install @ansvar/mcp-sqlite@^1.0.5` resolves to 1.0.5

## Test plan

- [ ] CI passes
- [ ] GHCR build workflow runs on merge to main
- [ ] Watchtower swap (~1 hour) or operator-triggered webhook