### PR TITLE
fix(ingest): acquire current consolidations (fin@latest), never as-enacted originals (#78)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,13 @@ data/seed_paid/
 # Downloaded source archives (cache for re-runs of ingestion)
 data/cache/
 
+# Version-keyed forensic copies of fetched consolidated XML (write-only audit
+# trail; one per statute/language/version - NEVER next to tracked corpus inputs)
+data/source-cache/
+
+# Run-stamped bulk-ingest reports (durable per-run records; finlex-bulk-latest.json stays tracked)
+reports/ingest/finlex-bulk-run-*.json
+
 # Bulk download artifacts from upstream
 *.tgz
 *.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,32 @@
 # Changelog
 
-All notable changes to the Swedish Law MCP Server will be documented in this file.
+All notable changes to the Finnish Law MCP Server will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased] - Corpus version-pin repair (issue #78)
+
+### Fixed
+- **Whole-corpus staleness:** all 2,053 statute seeds had been acquired from the
+  ORIGINAL as-enacted expression (`act/statute/{y}/{n}/fin@`, ELI `alkup`).
+  Acquisition now fetches the current consolidation
+  (`act/statute-consolidated/{y}/{n}/fin@latest`, ELI `ajantasa`) and falls back
+  to the original only on a definitive consolidated 404 (stamped + enumerated).
+- `check-updates` was structurally blind to amendments (it paged the original
+  statute list, whose entries never change on amendment); it now compares newest
+  consolidation version tokens against seed stamps.
+
+### Added
+- `_ingest` version-identity stamp in every seed (expression URI,
+  `consolidation_version`, `dateConsolidated`, ELI, per-language versions).
+- `npm run ingest:refresh` / `ingest:bulk --refresh --seeds-only` — version-keyed
+  refresh with unconditional self-heal for unstamped seeds, no corpus expansion.
+- Per-provision `metadata.amended_by` (from `finlex:originalVersionLabel`).
+- Transient≠gone HTTP discipline (5xx/429/network retry then THROW; 404 is a
+  finding) and a ≥2s politeness floor on all Finlex requests.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Corpus version-pin repair (issue #78)
 
+### Fixed (round 2 — adversarial-review findings on PR #79)
+
+- **Zero-provision gate (live damage class):** consolidated `contentAbsent`
+  shells silently overwrote seeds holding real statute text (~60 seeds hollowed
+  in the aborted first sweep; all seeds restored from git before this round).
+  A document parsing to zero provisions now NEVER becomes a seed: the
+  recognized contentAbsent shell triggers an explicit, stamped fallback to the
+  as-enacted original (`_ingest.consolidated_content_absent`); any other
+  zero-parse fails loud per-document (enumerated, non-zero exit). A last-line
+  tripwire refuses to replace a seed holding provisions with an empty one.
+- **Status is a fact, not a constant:** seeds were hardcoded `in_force` while
+  Finlex publishes `finlex:isInForce` / `dateInForceEnd` / `repealedBy` on
+  consolidated expressions (live-verified: repealed 523/1999 was being stamped
+  in force). Status now derives from lifecycle metadata, the facts are stamped
+  (`_ingest.lifecycle`, `_ingest.status_basis`), and repealed acts seed
+  `status: 'repealed'` (feeds the repealed-demotion downstream). As-enacted
+  originals carry no lifecycle metadata upstream — that cohort keeps the
+  documented default `in_force`, stamped `as_enacted_default_unverified`
+  (auditable, never disguised as a proven fact). `in_force_date` now uses
+  `dateEntryIntoForce` when published.
+- **check-updates conflations:** stamped-as-enacted (doc_type `statute`, the
+  legitimate consolidated-404 cohort, ~60% of the corpus) is no longer treated
+  as "unstamped / update-needed" (which would have made the checker exit 1
+  forever); a consolidation APPEARING upstream now flags an as-enacted seed
+  stale; a stamped-CONSOLIDATED seed absent from the upstream list is a loud
+  anomaly, not "up to date"; list entries that stop matching the URI shape are
+  counted and fail the run (no silent regex drops).
+- **404-downgrade guard:** a single unretried 404 on `fin@latest` no longer
+  silently downgrades a stamped consolidated seed to as-enacted text — the 404
+  is confirmed with a retry, and a persistent 404 for a previously-consolidated
+  statute throws a loud anomaly (enumerated in the run report).
+- **Stale-upstream guard:** an expression OLDER than the seed stamp (realistic
+  under the ~10-min `@latest` server cache) is never written back — the newer
+  seed is kept and the anomaly is enumerated (`stale_upstream` report bucket).
+- **Swedish skip-current hole:** `skip_current` now requires BOTH languages'
+  stamped versions to match upstream; seeds written with Swedish omitted are
+  re-examined each refresh until the Swedish consolidation catches up.
+- **provision_versions.valid_from** uses the consolidation date
+  (`dateConsolidated`) for consolidated text instead of claiming amended or
+  inserted provisions were valid from the original enactment date.
+- **Bare-`@` URL pinning:** single-version consolidations are served with a
+  bare-`@` FRBRuri; identities are pinned with the document's own
+  FRBRversionNumber so `seed.url` / stamps cannot re-resolve to the OLDEST
+  expression once a second consolidation appears.
+- **Body-identity check** (Dutch 976c0ef lesson): the served document's preface
+  identity must match the requested statute; mismatches throw, for both
+  languages.
+- **Atomic writes everywhere** (seeds, source cache, forensic copies, reports,
+  manifest, list cache) via tmp+rename; a corrupt as-enacted cache file now
+  self-heals (validated on read, removed, refetched) instead of poisoning every
+  later run.
+- **Forensic-copy pollution:** version-keyed consolidated XML copies moved out
+  of the git-tracked `data/source/finlex` into gitignored
+  `data/source-cache/finlex`, pruned to the newest version per statute and
+  language. The 368 copies the first sweep wrote into the tracked dir were
+  removed.
+- **Transport-outage abort:** 5 consecutive exhausted-retry transport failures
+  abort the sweep (observed live: 269 consecutive failures burned ~80 minutes
+  of retry exhaustion); HTTP 429 still aborts immediately.
+- **Durable run-stamped reports:** `reports/ingest/finlex-bulk-run-<ts>.json`
+  is flushed atomically after every statute, so a killed sweep leaves a
+  complete record; fixed-name `finlex-bulk-latest.json` remains as a
+  convenience copy.
+- **Refresh contract:** `npm run ingest:refresh` now includes `--seeds-only`
+  (a corpus refresh walks the EXISTING corpus; list-driven mode silently
+  expanded it from a stale cached catalogue).
+- **Legacy writer guard:** `auto-ingest-all-statutes.ts` and
+  `ingest-relevant-laws.ts` (Swedish-template Riksdagen leftovers writing
+  unstamped seeds into `data/seed/`) refuse to run without
+  `FORCE_LEGACY_INGEST=1`.
+
 ### Fixed
 - **Whole-corpus staleness:** all 2,053 statute seeds had been acquired from the
   ORIGINAL as-enacted expression (`act/statute/{y}/{n}/fin@`, ELI `alkup`).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:coverage": "vitest run --coverage",
     "ingest": "node --import tsx scripts/ingest-finlex.ts",
     "ingest:bulk": "node --import tsx scripts/ingest-finlex-bulk.ts",
+    "ingest:refresh": "node --import tsx scripts/ingest-finlex-bulk.ts --refresh",
     "ingest:current": "node --import tsx scripts/ingest-finlex-current.ts",
     "ingest:cases": "node --import tsx scripts/ingest-lagennu-cases.ts",
     "ingest:cases:full-archive": "node --import tsx scripts/ingest-lagennu-full-archive.ts",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:coverage": "vitest run --coverage",
     "ingest": "node --import tsx scripts/ingest-finlex.ts",
     "ingest:bulk": "node --import tsx scripts/ingest-finlex-bulk.ts",
-    "ingest:refresh": "node --import tsx scripts/ingest-finlex-bulk.ts --refresh",
+    "ingest:refresh": "node --import tsx scripts/ingest-finlex-bulk.ts --refresh --seeds-only",
     "ingest:current": "node --import tsx scripts/ingest-finlex-current.ts",
     "ingest:cases": "node --import tsx scripts/ingest-lagennu-cases.ts",
     "ingest:cases:full-archive": "node --import tsx scripts/ingest-lagennu-full-archive.ts",

--- a/scripts/auto-ingest-all-statutes.ts
+++ b/scripts/auto-ingest-all-statutes.ts
@@ -26,6 +26,21 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { ingest } from './ingest-riksdagen.js';
 
+// LEGACY GUARD (issue #78 round-2): this is a Swedish-template leftover that
+// fetches the SWEDISH parliament API (data.riksdagen.se) and writes UNSTAMPED
+// seeds straight into data/seed/, bypassing the version-stamped Finlex
+// acquisition entirely. Running it against the Finnish corpus corrupts it.
+if (process.env.FORCE_LEGACY_INGEST !== '1') {
+  console.error(
+    'REFUSING TO RUN: auto-ingest-all-statutes.ts is a LEGACY Swedish-template script ' +
+      '(Riksdagen API) that writes unstamped seeds into data/seed/, bypassing the ' +
+      'version-stamped Finlex acquisition (issue #78).\n' +
+      'Use `npm run ingest`, `npm run ingest:bulk`, or `npm run ingest:refresh` instead.\n' +
+      'Set FORCE_LEGACY_INGEST=1 to override (you almost certainly do not want this).'
+  );
+  process.exit(2);
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 

--- a/scripts/check-updates.ts
+++ b/scripts/check-updates.ts
@@ -19,11 +19,11 @@
 
 import Database from 'better-sqlite3';
 import * as path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import * as fs from 'fs';
 import { execFileSync } from 'child_process';
 import { FINLEX_REQUEST_DELAY_MS, FINLEX_USER_AGENT } from './lib/finlex-http.js';
-import { compareVersionNumbers, stampedVersionOf } from './lib/finlex-version.js';
+import { compareVersionNumbers, seedStampInfoOf, type SeedStampInfo } from './lib/finlex-version.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -84,12 +84,16 @@ function yearFromStatuteId(id: string): string | null {
   return null;
 }
 
-/** Parse '/act/statute-consolidated/{year}/{number}/fin@{version}' into id + version token. */
-function parseConsolidatedAknUri(uri: string | undefined): { id: string; version: string } | null {
+/** Parse '/act/statute-consolidated/{year}/{number}/{lang}@{version}' into id + lang + version token. */
+function parseConsolidatedAknUri(
+  uri: string | undefined
+): { id: string; lang: string; version: string } | null {
   if (!uri) return null;
-  const match = uri.match(/\/act\/statute-consolidated\/(\d{4})\/(\d+)(?:-\d+)?\/fin@([0-9a-zA-Z]*)$/u);
+  const match = uri.match(
+    /\/act\/statute-consolidated\/(\d{4})\/(\d+)(?:-\d+)?\/([a-z]{3})@([0-9a-zA-Z]*)$/u
+  );
   if (!match) return null;
-  return { id: `${match[2]}/${match[1]}`, version: match[3] };
+  return { id: `${match[2]}/${match[1]}`, lang: match[3], version: match[4] };
 }
 
 function newerVersion(current: string | undefined, incoming: string): string {
@@ -101,9 +105,73 @@ function newerVersion(current: string | undefined, incoming: string): string {
   return compareVersionNumbers(incoming, current) > 0 ? incoming : current;
 }
 
+export interface ListShapeStats {
+  entriesSeen: number;
+  finCount: number;
+  otherLanguageCount: number;
+  unrecognized: string[];
+}
+
+/**
+ * Fold one page of consolidated-list entries into the versions map, counting
+ * exactly what was seen. Entries that match no recognized shape are RECORDED,
+ * never silently dropped — if the upstream URI shape drifts, the run must
+ * fail loud instead of reporting "0 statutes, everything current".
+ */
+export function collectNewestVersions(
+  entries: RemoteEntry[],
+  versions: Map<string, string>
+): ListShapeStats {
+  const stats: ListShapeStats = {
+    entriesSeen: entries.length,
+    finCount: 0,
+    otherLanguageCount: 0,
+    unrecognized: [],
+  };
+  for (const entry of entries) {
+    const parsed = parseConsolidatedAknUri(entry.akn_uri);
+    if (!parsed) {
+      stats.unrecognized.push(entry.akn_uri ?? '(no akn_uri)');
+      continue;
+    }
+    if (parsed.lang !== 'fin') {
+      stats.otherLanguageCount += 1; // Swedish twins are expected, not drift
+      continue;
+    }
+    stats.finCount += 1;
+    versions.set(parsed.id, newerVersion(versions.get(parsed.id), parsed.version));
+  }
+  return stats;
+}
+
+/** Fail loud on list shape drift: unrecognized entries or an all-entries-unparseable page set. */
+export function assertListShape(stats: ListShapeStats, context: string): void {
+  if (stats.unrecognized.length > 0) {
+    const sample = stats.unrecognized.slice(0, 5).join(', ');
+    throw new Error(
+      `${context}: ${stats.unrecognized.length} unrecognized consolidated-list entr(ies) — upstream URI ` +
+        `shape drift, refusing to report freshness from a partial parse (sample: ${sample})`
+    );
+  }
+  if (stats.entriesSeen > 0 && stats.finCount === 0) {
+    throw new Error(
+      `${context}: ${stats.entriesSeen} list entries but NONE parsed as a fin@ consolidated URI — ` +
+        'shape drift, refusing to conclude "no consolidated works upstream"'
+    );
+  }
+}
+
+function mergeStats(into: ListShapeStats, page: ListShapeStats): void {
+  into.entriesSeen += page.entriesSeen;
+  into.finCount += page.finCount;
+  into.otherLanguageCount += page.otherLanguageCount;
+  into.unrecognized.push(...page.unrecognized);
+}
+
 /** Newest consolidation version token per statute id, for one work year. */
 async function fetchNewestVersionsForYear(year: string): Promise<Map<string, string>> {
   const versions = new Map<string, string>();
+  const yearStats: ListShapeStats = { entriesSeen: 0, finCount: 0, otherLanguageCount: 0, unrecognized: [] };
 
   for (let page = 1; page <= MAX_PAGES_PER_YEAR; page++) {
     const params = new URLSearchParams({
@@ -149,11 +217,7 @@ async function fetchNewestVersionsForYear(year: string): Promise<Map<string, str
       break;
     }
 
-    for (const entry of entries) {
-      const parsed = parseConsolidatedAknUri(entry.akn_uri);
-      if (!parsed) continue;
-      versions.set(parsed.id, newerVersion(versions.get(parsed.id), parsed.version));
-    }
+    mergeStats(yearStats, collectNewestVersions(entries, versions));
 
     if (entries.length < PAGE_LIMIT) {
       break;
@@ -166,18 +230,104 @@ async function fetchNewestVersionsForYear(year: string): Promise<Map<string, str
     await delay(REQUEST_DELAY_MS);
   }
 
+  assertListShape(yearStats, `year ${year}`);
   return versions;
 }
 
-function stampFor(statuteId: string): string | null {
+function stampInfoFor(statuteId: string): SeedStampInfo | null {
   const safe = toFinnishStatuteId(statuteId).replace('/', '_');
   const seedPath = path.join(SEED_DIR, `${safe}.json`);
   if (!fs.existsSync(seedPath)) return null;
   try {
-    return stampedVersionOf(JSON.parse(fs.readFileSync(seedPath, 'utf-8')));
+    return seedStampInfoOf(JSON.parse(fs.readFileSync(seedPath, 'utf-8')));
   } catch {
     return null;
   }
+}
+
+const VERSION_TOKEN_RE = /^\d{8}$/u;
+
+export interface FreshnessVerdict {
+  has_update: boolean;
+  stamped_version: string | null;
+  error?: string;
+}
+
+/**
+ * Classify one seed's freshness from its full stamp identity vs the newest
+ * upstream consolidation version (null = absent from the consolidated list).
+ *
+ * The load-bearing distinctions (PR #79 round-2):
+ *  - stamped AS-ENACTED (doc_type 'statute', consolidation_version null) is
+ *    NOT "unstamped": the stamp PROVES the as-enacted expression is the
+ *    current text when no consolidated work exists upstream.
+ *  - a consolidation APPEARING upstream makes an as-enacted seed stale.
+ *  - a stamped-CONSOLIDATED seed missing from the consolidated list is an
+ *    anomaly to surface, never silently "up to date".
+ */
+export function classifySeedFreshness(
+  stamp: SeedStampInfo | null,
+  remote: string | null
+): FreshnessVerdict {
+  if (!stamp || stamp.doc_type === null) {
+    return {
+      has_update: true,
+      stamped_version: null,
+      error: 'No ingest stamp — freshness unprovable, re-ingest (self-heal)',
+    };
+  }
+
+  const remoteValid = remote !== null && VERSION_TOKEN_RE.test(remote);
+
+  // The version that proves which consolidation the seed reflects: for
+  // contentAbsent fallbacks that is the stamped SHELL version.
+  const effectiveVersion = stamp.consolidation_version ?? stamp.content_absent_version;
+
+  if (effectiveVersion === null) {
+    // Stamped as-enacted: the legitimate consolidated-404 cohort.
+    if (stamp.doc_type !== 'statute') {
+      return {
+        has_update: true,
+        stamped_version: null,
+        error: 'Consolidated stamp without a version token — unprovable, re-ingest (self-heal)',
+      };
+    }
+    if (remoteValid) {
+      return {
+        has_update: true,
+        stamped_version: null,
+        error: `Consolidation ${remote} appeared upstream — as-enacted seed is stale, re-ingest`,
+      };
+    }
+    // No consolidated work upstream: the stamped as-enacted original IS the
+    // current text. Proven, not assumed.
+    return { has_update: false, stamped_version: null };
+  }
+
+  if (!VERSION_TOKEN_RE.test(effectiveVersion)) {
+    return {
+      has_update: true,
+      stamped_version: effectiveVersion,
+      error: `Unparseable stamped version "${effectiveVersion}" — unprovable, re-ingest (self-heal)`,
+    };
+  }
+
+  if (!remoteValid) {
+    // The stamp PROVES a consolidated work existed upstream; its absence from
+    // the consolidated list is an anomaly, not a green light.
+    return {
+      has_update: true,
+      stamped_version: effectiveVersion,
+      error:
+        `Stamped consolidation ${effectiveVersion} but the statute is ABSENT from the upstream ` +
+        'consolidated list — anomaly, investigate before trusting freshness',
+    };
+  }
+
+  return {
+    has_update: compareVersionNumbers(remote as string, effectiveVersion) > 0,
+    stamped_version: effectiveVersion,
+  };
 }
 
 async function checkUpdates(): Promise<void> {
@@ -235,41 +385,17 @@ async function checkUpdates(): Promise<void> {
   const results: UpdateCheckResult[] = [];
   for (const doc of documents) {
     const finlexId = toFinnishStatuteId(doc.id);
-    const stamped = stampFor(doc.id);
+    const stamp = stampInfoFor(doc.id);
     const remote = remoteVersions.get(finlexId) ?? null;
+    const verdict = classifySeedFreshness(stamp, remote);
 
-    if (!stamped) {
-      results.push({
-        id: doc.id,
-        title: doc.title,
-        stamped_version: null,
-        remote_version: remote,
-        has_update: true,
-        error: 'No consolidation stamp — freshness unprovable, re-ingest (self-heal)',
-      });
-      continue;
-    }
-
-    if (!remote || !/^\d{8}$/u.test(remote)) {
-      // No consolidated work upstream: the as-enacted original is the current
-      // text. The stamp records which expression we hold; nothing to compare.
-      results.push({
-        id: doc.id,
-        title: doc.title,
-        stamped_version: stamped,
-        remote_version: remote,
-        has_update: false,
-      });
-      continue;
-    }
-
-    const hasUpdate = !/^\d{8}$/u.test(stamped) || compareVersionNumbers(remote, stamped) > 0;
     results.push({
       id: doc.id,
       title: doc.title,
-      stamped_version: stamped,
+      stamped_version: verdict.stamped_version,
       remote_version: remote,
-      has_update: hasUpdate,
+      has_update: verdict.has_update,
+      error: verdict.error,
     });
   }
 
@@ -277,7 +403,7 @@ async function checkUpdates(): Promise<void> {
   for (const result of results) {
     process.stdout.write(`  ${result.id} (${result.title.substring(0, 48)})... `);
     if (result.error) {
-      console.log(`needs re-ingest: ${result.error}`);
+      console.log(`needs attention: ${result.error}`);
     } else if (result.has_update) {
       console.log(`UPDATE AVAILABLE (${result.stamped_version} -> ${result.remote_version})`);
     } else {
@@ -315,7 +441,9 @@ async function checkUpdates(): Promise<void> {
   }
 }
 
-checkUpdates().catch(error => {
-  console.error('Check failed:', error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  checkUpdates().catch(error => {
+    console.error('Check failed:', error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/check-updates.ts
+++ b/scripts/check-updates.ts
@@ -2,10 +2,19 @@
 /**
  * Check for updates to ingested Finnish statutes.
  *
- * Uses Finlex open data list endpoints and compares remote per-statute status
- * (NEW/MODIFIED) against locally seeded statutes in data/database.db.
+ * Version-keyed (issue #78): pages the statute-CONSOLIDATED list, takes the
+ * newest consolidation version token (`fin@YYYYNNNN`) per statute, and
+ * compares it against the `_ingest.consolidation_version` stamp in the local
+ * seed files. The previous implementation paged the ORIGINAL statute list,
+ * whose entries never change when a statute is amended — it was structurally
+ * blind to exactly the staleness it was meant to detect.
+ *
+ * A statute whose seed carries no stamp is reported as update-needed: its
+ * freshness cannot be proven (it predates version-stamped acquisition and may
+ * hold as-enacted text).
  *
  * Usage: npm run check-updates
+ * Exit codes: 0 = everything provably current, 1 = updates needed or errors.
  */
 
 import Database from 'better-sqlite3';
@@ -13,16 +22,20 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import * as fs from 'fs';
 import { execFileSync } from 'child_process';
+import { FINLEX_REQUEST_DELAY_MS, FINLEX_USER_AGENT } from './lib/finlex-http.js';
+import { compareVersionNumbers, stampedVersionOf } from './lib/finlex-version.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DB_PATH = path.resolve(__dirname, '../data/database.db');
+const SEED_DIR = path.resolve(__dirname, '../data/seed');
 
-const FINLEX_LIST_URL = 'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute/list';
-const USER_AGENT = 'Finnish-Law-MCP/1.2.2 (https://github.com/Ansvar-Systems/finnish-law-mcp)';
-const REQUEST_DELAY_MS = 250;
+const FINLEX_CONSOLIDATED_LIST_URL =
+  'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute-consolidated/list';
+const USER_AGENT = FINLEX_USER_AGENT;
+const REQUEST_DELAY_MS = FINLEX_REQUEST_DELAY_MS; // politeness floor: >=2s per request
 const PAGE_LIMIT = 10; // Finlex list endpoint enforces max 10
-const MAX_PAGES_PER_YEAR = 50;
+const MAX_PAGES_PER_YEAR = 400;
 
 interface LocalDocument {
   id: string;
@@ -40,8 +53,8 @@ interface RemoteEntry {
 interface UpdateCheckResult {
   id: string;
   title: string;
-  local_date: string | null;
-  remote_status: string | null;
+  stamped_version: string | null;
+  remote_version: string | null;
   has_update: boolean;
   error?: string;
 }
@@ -71,41 +84,38 @@ function yearFromStatuteId(id: string): string | null {
   return null;
 }
 
-function parseFinnishIdFromAknUri(uri: string | undefined): string | null {
+/** Parse '/act/statute-consolidated/{year}/{number}/fin@{version}' into id + version token. */
+function parseConsolidatedAknUri(uri: string | undefined): { id: string; version: string } | null {
   if (!uri) return null;
-  const match = uri.match(/\/act\/statute\/(\d{4})\/(\d+)\/(?:fin|swe)@/u);
+  const match = uri.match(/\/act\/statute-consolidated\/(\d{4})\/(\d+)(?:-\d+)?\/fin@([0-9a-zA-Z]*)$/u);
   if (!match) return null;
-  return `${match[2]}/${match[1]}`;
+  return { id: `${match[2]}/${match[1]}`, version: match[3] };
 }
 
-function mergeStatus(current: string | undefined, next: string | undefined): string {
-  const normalizedCurrent = (current ?? '').toUpperCase();
-  const normalizedNext = (next ?? '').toUpperCase();
-  if (normalizedCurrent === 'MODIFIED' || normalizedNext === 'MODIFIED') {
-    return 'MODIFIED';
-  }
-  if (normalizedCurrent === 'NEW' || normalizedNext === 'NEW') {
-    return 'NEW';
-  }
-  return normalizedNext || normalizedCurrent || 'UNKNOWN';
+function newerVersion(current: string | undefined, incoming: string): string {
+  if (!current) return incoming;
+  // Bare '@' (empty token) is the enactment-dated expression — any dated
+  // token outranks it.
+  if (!/^\d{8}$/u.test(incoming)) return current;
+  if (!/^\d{8}$/u.test(current)) return incoming;
+  return compareVersionNumbers(incoming, current) > 0 ? incoming : current;
 }
 
-async function fetchRemoteStatusesForYear(year: string): Promise<Map<string, string>> {
-  const statuses = new Map<string, string>();
+/** Newest consolidation version token per statute id, for one work year. */
+async function fetchNewestVersionsForYear(year: string): Promise<Map<string, string>> {
+  const versions = new Map<string, string>();
 
   for (let page = 1; page <= MAX_PAGES_PER_YEAR; page++) {
     const params = new URLSearchParams({
       format: 'json',
       page: String(page),
       limit: String(PAGE_LIMIT),
-      sortBy: 'dateIssued',
+      sortBy: 'number',
       startYear: year,
       endYear: year,
-      LangAndVersion: 'fin@',
-      typeStatute: 'act',
     });
 
-    const url = `${FINLEX_LIST_URL}?${params.toString()}`;
+    const url = `${FINLEX_CONSOLIDATED_LIST_URL}?${params.toString()}`;
     const raw = execFileSync(
       'curl',
       [
@@ -140,25 +150,38 @@ async function fetchRemoteStatusesForYear(year: string): Promise<Map<string, str
     }
 
     for (const entry of entries) {
-      const statuteId = parseFinnishIdFromAknUri(entry.akn_uri);
-      if (!statuteId) continue;
-
-      const existing = statuses.get(statuteId);
-      statuses.set(statuteId, mergeStatus(existing, entry.status));
+      const parsed = parseConsolidatedAknUri(entry.akn_uri);
+      if (!parsed) continue;
+      versions.set(parsed.id, newerVersion(versions.get(parsed.id), parsed.version));
     }
 
     if (entries.length < PAGE_LIMIT) {
       break;
     }
+    if (page === MAX_PAGES_PER_YEAR) {
+      // Never silently truncate: a partial list would mask updates.
+      throw new Error(`year ${year}: consolidated list exceeds ${MAX_PAGES_PER_YEAR} pages — raise the cap`);
+    }
 
     await delay(REQUEST_DELAY_MS);
   }
 
-  return statuses;
+  return versions;
+}
+
+function stampFor(statuteId: string): string | null {
+  const safe = toFinnishStatuteId(statuteId).replace('/', '_');
+  const seedPath = path.join(SEED_DIR, `${safe}.json`);
+  if (!fs.existsSync(seedPath)) return null;
+  try {
+    return stampedVersionOf(JSON.parse(fs.readFileSync(seedPath, 'utf-8')));
+  } catch {
+    return null;
+  }
 }
 
 async function checkUpdates(): Promise<void> {
-  console.log('Finnish Law MCP - Update Checker');
+  console.log('Finnish Law MCP - Update Checker (version-keyed, statute-consolidated)');
   console.log('');
 
   if (!fs.existsSync(DB_PATH)) {
@@ -190,15 +213,15 @@ async function checkUpdates(): Promise<void> {
   console.log(`Checking ${documents.length} statute(s) across ${years.size} year bucket(s)...`);
   console.log('');
 
-  const remoteStatuses = new Map<string, string>();
+  const remoteVersions = new Map<string, string>();
   const remoteFetchErrors: string[] = [];
 
-  for (const year of years) {
+  for (const year of [...years].sort()) {
     try {
-      process.stdout.write(`  Loading Finlex list for ${year}... `);
-      const byYear = await fetchRemoteStatusesForYear(year);
-      for (const [id, status] of byYear) {
-        remoteStatuses.set(id, mergeStatus(remoteStatuses.get(id), status));
+      process.stdout.write(`  Loading consolidated list for ${year}... `);
+      const byYear = await fetchNewestVersionsForYear(year);
+      for (const [id, version] of byYear) {
+        remoteVersions.set(id, newerVersion(remoteVersions.get(id), version));
       }
       console.log(`${byYear.size} statute(s)`);
     } catch (error) {
@@ -212,26 +235,40 @@ async function checkUpdates(): Promise<void> {
   const results: UpdateCheckResult[] = [];
   for (const doc of documents) {
     const finlexId = toFinnishStatuteId(doc.id);
-    const remoteStatus = remoteStatuses.get(finlexId) ?? null;
-    const hasUpdate = remoteStatus === 'MODIFIED';
+    const stamped = stampFor(doc.id);
+    const remote = remoteVersions.get(finlexId) ?? null;
 
-    if (!remoteStatus) {
+    if (!stamped) {
       results.push({
         id: doc.id,
         title: doc.title,
-        local_date: doc.last_updated,
-        remote_status: null,
-        has_update: false,
-        error: 'Not found in Finlex list results',
+        stamped_version: null,
+        remote_version: remote,
+        has_update: true,
+        error: 'No consolidation stamp — freshness unprovable, re-ingest (self-heal)',
       });
       continue;
     }
 
+    if (!remote || !/^\d{8}$/u.test(remote)) {
+      // No consolidated work upstream: the as-enacted original is the current
+      // text. The stamp records which expression we hold; nothing to compare.
+      results.push({
+        id: doc.id,
+        title: doc.title,
+        stamped_version: stamped,
+        remote_version: remote,
+        has_update: false,
+      });
+      continue;
+    }
+
+    const hasUpdate = !/^\d{8}$/u.test(stamped) || compareVersionNumbers(remote, stamped) > 0;
     results.push({
       id: doc.id,
       title: doc.title,
-      local_date: doc.last_updated,
-      remote_status: remoteStatus,
+      stamped_version: stamped,
+      remote_version: remote,
       has_update: hasUpdate,
     });
   }
@@ -240,17 +277,17 @@ async function checkUpdates(): Promise<void> {
   for (const result of results) {
     process.stdout.write(`  ${result.id} (${result.title.substring(0, 48)})... `);
     if (result.error) {
-      console.log(`error: ${result.error}`);
+      console.log(`needs re-ingest: ${result.error}`);
     } else if (result.has_update) {
-      console.log('UPDATE AVAILABLE');
+      console.log(`UPDATE AVAILABLE (${result.stamped_version} -> ${result.remote_version})`);
     } else {
-      console.log(`up to date (${result.remote_status})`);
+      console.log(`up to date (${result.stamped_version ?? 'as-enacted, no consolidation upstream'})`);
     }
   }
 
   const updates = results.filter(r => r.has_update);
-  const errors = [...remoteFetchErrors, ...results.filter(r => r.error).map(r => `${r.id}: ${r.error}`)];
-  const current = results.filter(r => !r.has_update && !r.error);
+  const errors = remoteFetchErrors;
+  const current = results.filter(r => !r.has_update);
 
   console.log('');
   console.log(`Up to date: ${current.length}`);
@@ -260,11 +297,20 @@ async function checkUpdates(): Promise<void> {
   if (updates.length > 0) {
     console.log('');
     console.log('To re-ingest updated statutes:');
-    for (const u of updates) {
+    console.log('  npm run ingest:refresh');
+    console.log('or per statute:');
+    for (const u of updates.slice(0, 20)) {
       const safeId = toFinnishStatuteId(u.id).replace('/', '_');
       console.log(`  npm run ingest -- ${toFinnishStatuteId(u.id)} data/seed/${safeId}.json`);
     }
+    if (updates.length > 20) {
+      console.log(`  ... and ${updates.length - 20} more`);
+    }
     console.log('  npm run build:db');
+    process.exit(1);
+  }
+
+  if (errors.length > 0) {
     process.exit(1);
   }
 }

--- a/scripts/check-updates.ts
+++ b/scripts/check-updates.ts
@@ -278,6 +278,12 @@ export function classifySeedFreshness(
   }
 
   const remoteValid = remote !== null && VERSION_TOKEN_RE.test(remote);
+  // Live-verified (2026-06-11): never-amended consolidations appear in the
+  // consolidated list ONLY as bare-@ akn_uris (empty version token), while
+  // the served document carries a real FRBRversionNumber. Present-but-bare
+  // therefore means "a consolidation exists, exactly one version" — it is
+  // NEITHER absent NOR a dated comparison target.
+  const remoteBare = remote === '';
 
   // The version that proves which consolidation the seed reflects: for
   // contentAbsent fallbacks that is the stamped SHELL version.
@@ -292,11 +298,11 @@ export function classifySeedFreshness(
         error: 'Consolidated stamp without a version token — unprovable, re-ingest (self-heal)',
       };
     }
-    if (remoteValid) {
+    if (remoteValid || remoteBare) {
       return {
         has_update: true,
         stamped_version: null,
-        error: `Consolidation ${remote} appeared upstream — as-enacted seed is stale, re-ingest`,
+        error: `Consolidation ${remoteBare ? '(single-version)' : remote} appeared upstream — as-enacted seed is stale, re-ingest`,
       };
     }
     // No consolidated work upstream: the stamped as-enacted original IS the
@@ -310,6 +316,12 @@ export function classifySeedFreshness(
       stamped_version: effectiveVersion,
       error: `Unparseable stamped version "${effectiveVersion}" — unprovable, re-ingest (self-heal)`,
     };
+  }
+
+  if (remoteBare) {
+    // Stamped consolidated + bare-@ list entry: the single-version cohort.
+    // Our stamp IS that one version — current, proven.
+    return { has_update: false, stamped_version: effectiveVersion };
   }
 
   if (!remoteValid) {

--- a/scripts/ingest-finlex-bulk.ts
+++ b/scripts/ingest-finlex-bulk.ts
@@ -8,9 +8,17 @@
  * - Ingest each statute into deterministic `data/seed/{number}_{year}.json`
  * - Write ingestion report + manifest for reproducibility
  *
+ * Version discipline (issue #78): each statute is acquired from the CURRENT
+ * consolidation (statute-consolidated/{y}/{n}/fin@latest) and version-stamped
+ * (`_ingest`). `--refresh` re-walks existing seeds keyed on that stamp:
+ * unstamped seeds (pre-fix, as-enacted content) self-heal unconditionally;
+ * stamped seeds are refetched and rewritten only when upstream has a newer
+ * consolidation.
+ *
  * Usage:
  *   npm run ingest:bulk
  *   npm run ingest:bulk -- --from-year 2000 --resume
+ *   npm run ingest:bulk -- --refresh
  *   npm run ingest:bulk -- --limit 250
  *   npm run ingest:bulk -- --cache-only
  */
@@ -19,12 +27,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 import { pathToFileURL } from 'url';
-import { ingestFinlexStatute } from './ingest-finlex.js';
+import { ingestFinlexStatute, type IngestOutcome } from './ingest-finlex.js';
+import { FINLEX_REQUEST_DELAY_MS, FINLEX_USER_AGENT } from './lib/finlex-http.js';
+import { decideFetch, stampedVersionOf } from './lib/finlex-version.js';
 
 const FINLEX_LIST_URL = 'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute/list';
-const USER_AGENT = 'Finnish-Law-MCP/1.2.2 (https://github.com/Ansvar-Systems/finnish-law-mcp)';
+const USER_AGENT = FINLEX_USER_AGENT;
 const PAGE_LIMIT = 10; // Finlex endpoint enforces limit <= 10
-const REQUEST_DELAY_MS = 300;
+const REQUEST_DELAY_MS = FINLEX_REQUEST_DELAY_MS; // politeness floor: >=2s per request
 const SEED_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../data/seed');
 const LIST_CACHE_PATH = path.resolve(
   path.dirname(new URL(import.meta.url).pathname),
@@ -45,6 +55,8 @@ interface CLIOptions {
   limit?: number;
   maxPages: number;
   resume: boolean;
+  /** Version-keyed refresh of existing seeds (overrides --resume skipping). */
+  refresh: boolean;
   refreshList: boolean;
   cacheOnly: boolean;
 }
@@ -85,6 +97,12 @@ interface IngestionReport {
   selected_candidates: number;
   ingested: number;
   skipped_existing: number;
+  /** Refresh runs: seeds whose stamped consolidation already matches upstream. */
+  skipped_current: number;
+  /** Statutes with no consolidated document upstream (definitive 404) — as-enacted original acquired. */
+  consolidation_absent: string[];
+  /** Statutes whose Swedish text was omitted, by reason. */
+  swedish_omitted: { not_available: string[]; version_mismatch: string[] };
   failed: number;
   aborted_reason?: string;
   failures: IngestionFailure[];
@@ -153,6 +171,7 @@ function parseArgs(argv: string[]): CLIOptions {
   const options: CLIOptions = {
     maxPages: 5000,
     resume: false,
+    refresh: false,
     refreshList: false,
     cacheOnly: false,
   };
@@ -162,6 +181,8 @@ function parseArgs(argv: string[]): CLIOptions {
 
     if (arg === '--resume') {
       options.resume = true;
+    } else if (arg === '--refresh') {
+      options.refresh = true;
     } else if (arg === '--refresh-list') {
       options.refreshList = true;
     } else if (arg === '--cache-only') {
@@ -190,6 +211,8 @@ function parseArgs(argv: string[]): CLIOptions {
       console.log('  --to-year <YYYY>     Include statutes up to this year');
       console.log('  --limit <N>          Ingest at most N deduplicated statutes');
       console.log('  --resume             Skip statutes whose seed files already exist');
+      console.log('  --refresh            Version-keyed refresh: refetch seeds whose stamped');
+      console.log('                       consolidation is older than upstream; self-heal unstamped seeds');
       console.log('  --refresh-list       Force refresh list from Finlex API');
       console.log('  --cache-only         Use cached list only (no network calls)');
       console.log('  --max-pages <N>      Safety cap for paginated list loading');
@@ -408,6 +431,7 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
   console.log(`  toYear:   ${options.toYear ?? 'all'}`);
   console.log(`  limit:    ${options.limit ?? 'none'}`);
   console.log(`  resume:   ${options.resume ? 'yes' : 'no'}`);
+  console.log(`  refresh:  ${options.refresh ? 'yes (version-keyed)' : 'no'}`);
   console.log('');
 
   const entries = await loadListEntries(options);
@@ -427,6 +451,9 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
     selected_candidates: selected.length,
     ingested: 0,
     skipped_existing: 0,
+    skipped_current: 0,
+    consolidation_absent: [],
+    swedish_omitted: { not_available: [], version_mismatch: [] },
     failed: 0,
     failures: [],
   };
@@ -439,22 +466,52 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
   for (let i = 0; i < selected.length; i++) {
     const candidate = selected[i];
     const outputPath = outputPathFor(candidate);
+    const seedExists = fs.existsSync(outputPath);
 
-    if (options.resume && fs.existsSync(outputPath)) {
+    // Version-keyed fetch decision. Outside refresh mode this preserves the
+    // historical behavior exactly: --resume skips existing seeds, a plain run
+    // re-ingests everything.
+    let stampedVersion: string | null = null;
+    if (seedExists && options.refresh) {
+      try {
+        stampedVersion = stampedVersionOf(JSON.parse(fs.readFileSync(outputPath, 'utf-8')));
+      } catch {
+        stampedVersion = null; // unreadable seed: self-heal via refetch_unknown
+      }
+      const decision = decideFetch({ seedExists, refresh: true, stampedVersion });
+      console.log(
+        `[${i + 1}/${selected.length}] ${decision} ${candidate.canonical_id}` +
+          (stampedVersion ? ` (stamped ${stampedVersion})` : ' (unstamped — self-heal)')
+      );
+    } else if (options.resume && seedExists) {
       report.skipped_existing += 1;
       if ((i + 1) % 50 === 0) {
         console.log(`[${i + 1}/${selected.length}] resume-skip ${candidate.canonical_id}`);
       }
       continue;
+    } else {
+      console.log(`[${i + 1}/${selected.length}] ingest ${candidate.canonical_id} (source ${candidate.number_token})`);
     }
 
-    console.log(`[${i + 1}/${selected.length}] ingest ${candidate.canonical_id} (source ${candidate.number_token})`);
     try {
-      await ingestFinlexStatute(candidate.canonical_id, outputPath, {
+      const outcome: IngestOutcome = await ingestFinlexStatute(candidate.canonical_id, outputPath, {
         fetchNumberToken: candidate.number_token,
         canonicalStatuteId: candidate.canonical_id,
+        existingStampedVersion: stampedVersion,
       });
-      report.ingested += 1;
+      if (outcome.decision === 'skip_current' || !outcome.written) {
+        report.skipped_current += 1;
+      } else {
+        report.ingested += 1;
+      }
+      if (outcome.consolidationAbsent) {
+        report.consolidation_absent.push(candidate.canonical_id);
+      }
+      if (outcome.swedish === 'omitted_not_available') {
+        report.swedish_omitted.not_available.push(candidate.canonical_id);
+      } else if (outcome.swedish === 'omitted_version_mismatch') {
+        report.swedish_omitted.version_mismatch.push(candidate.canonical_id);
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       report.failed += 1;
@@ -480,14 +537,17 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
 
   console.log('');
   console.log('Bulk ingestion summary');
-  console.log(`  Ingested:        ${report.ingested}`);
-  console.log(`  Skipped existing:${report.skipped_existing}`);
-  console.log(`  Failed:          ${report.failed}`);
+  console.log(`  Ingested (written):    ${report.ingested}`);
+  console.log(`  Skipped existing:      ${report.skipped_existing}`);
+  console.log(`  Skipped current:       ${report.skipped_current}`);
+  console.log(`  Consolidation absent:  ${report.consolidation_absent.length} (as-enacted original acquired)`);
+  console.log(`  Swedish omitted:       ${report.swedish_omitted.not_available.length} unavailable, ${report.swedish_omitted.version_mismatch.length} version-mismatch`);
+  console.log(`  Failed:                ${report.failed}`);
   if (report.aborted_reason) {
-    console.log(`  Aborted reason:  ${report.aborted_reason}`);
+    console.log(`  Aborted reason:        ${report.aborted_reason}`);
   }
-  console.log(`  Report:          ${REPORT_PATH}`);
-  console.log(`  Manifest:        ${MANIFEST_PATH}`);
+  console.log(`  Report:                ${REPORT_PATH}`);
+  console.log(`  Manifest:              ${MANIFEST_PATH}`);
 
   if (report.failed > 0) {
     process.exitCode = 1;

--- a/scripts/ingest-finlex-bulk.ts
+++ b/scripts/ingest-finlex-bulk.ts
@@ -29,7 +29,8 @@ import { execFileSync } from 'child_process';
 import { pathToFileURL } from 'url';
 import { ingestFinlexStatute, type IngestOutcome } from './ingest-finlex.js';
 import { FINLEX_REQUEST_DELAY_MS, FINLEX_USER_AGENT } from './lib/finlex-http.js';
-import { decideFetch, stampedVersionOf } from './lib/finlex-version.js';
+import { decideFetch, stampedLanguageVersionsOf, stampedVersionOf } from './lib/finlex-version.js';
+import { writeFileAtomicSync } from './lib/fs-atomic.js';
 
 const FINLEX_LIST_URL = 'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute/list';
 const USER_AGENT = FINLEX_USER_AGENT;
@@ -40,10 +41,37 @@ const LIST_CACHE_PATH = path.resolve(
   path.dirname(new URL(import.meta.url).pathname),
   '../data/source/finlex/statute-list-fin.json'
 );
-const REPORT_PATH = path.resolve(
+const REPORT_DIR = path.resolve(
   path.dirname(new URL(import.meta.url).pathname),
-  '../reports/ingest/finlex-bulk-latest.json'
+  '../reports/ingest'
 );
+const REPORT_PATH = path.join(REPORT_DIR, 'finlex-bulk-latest.json');
+
+/**
+ * Durable, run-stamped report path (Dutch round-2 lesson: report files are
+ * run-stamped, never a fixed name a later smoke run overwrites). The report
+ * is flushed after every candidate so a killed sweep still leaves a complete
+ * record of what it did.
+ */
+export function runReportPath(startedAt: string): string {
+  const stamp = startedAt.replace(/\.\d{3}Z$/u, 'Z').replace(/:/gu, '-');
+  return path.join(REPORT_DIR, `finlex-bulk-run-${stamp}.json`);
+}
+
+/**
+ * Failure taxonomy for the abort policy: rate limiting and sustained
+ * transport outages must stop the sweep (continuing burns the whole worklist
+ * at retry-exhaustion speed); per-document failures are enumerated and the
+ * sweep moves on.
+ */
+export function classifyIngestFailure(message: string): 'rate_limited' | 'transport' | 'other' {
+  if (/HTTP 429/u.test(message)) return 'rate_limited';
+  if (/failed after \d+ attempts/u.test(message)) return 'transport';
+  return 'other';
+}
+
+/** Consecutive exhausted-retry transport failures that abort the sweep. */
+export const TRANSPORT_ABORT_THRESHOLD = 5;
 const MANIFEST_PATH = path.resolve(
   path.dirname(new URL(import.meta.url).pathname),
   '../data/seed/_finlex-statutes-manifest.json'
@@ -107,6 +135,10 @@ interface IngestionReport {
   skipped_current: number;
   /** Statutes with no consolidated document upstream (definitive 404) — as-enacted original acquired. */
   consolidation_absent: string[];
+  /** Consolidated expression was an empty contentAbsent shell — as-enacted text seeded, stamped. */
+  content_absent_fallback: string[];
+  /** Upstream served an expression OLDER than the seed stamp — newer seed kept, anomaly surfaced. */
+  stale_upstream: string[];
   /** Statutes whose Swedish text was omitted, by reason. */
   swedish_omitted: { not_available: string[]; version_mismatch: string[] };
   failed: number;
@@ -384,7 +416,7 @@ async function loadListEntries(options: CLIOptions): Promise<RemoteEntry[]> {
     },
     entries,
   };
-  fs.writeFileSync(LIST_CACHE_PATH, JSON.stringify(payload, null, 2), 'utf-8');
+  writeFileAtomicSync(LIST_CACHE_PATH, JSON.stringify(payload, null, 2));
   console.log(`Cached list payload: ${LIST_CACHE_PATH}`);
 
   return entries;
@@ -485,7 +517,7 @@ function writeManifest(candidates: StatuteCandidate[]): void {
     })),
   };
 
-  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2), 'utf-8');
+  writeFileAtomicSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
 }
 
 export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): Promise<void> {
@@ -535,15 +567,25 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
     skipped_existing: 0,
     skipped_current: 0,
     consolidation_absent: [],
+    content_absent_fallback: [],
+    stale_upstream: [],
     swedish_omitted: { not_available: [], version_mismatch: [] },
     failed: 0,
     failures: [],
+  };
+  const durableReportPath = runReportPath(startedAt);
+  const flushReport = (): void => {
+    report.finished_at = new Date().toISOString();
+    writeFileAtomicSync(durableReportPath, JSON.stringify(report, null, 2));
   };
 
   console.log(`List entries loaded:      ${listEntryCount}`);
   console.log(`Unique statute candidates: ${allCandidates.length}`);
   console.log(`Selected for ingestion:    ${selected.length}`);
+  console.log(`Run report (flushed per statute): ${durableReportPath}`);
   console.log('');
+
+  let consecutiveTransportFailures = 0;
 
   for (let i = 0; i < selected.length; i++) {
     const candidate = selected[i];
@@ -554,11 +596,15 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
     // historical behavior exactly: --resume skips existing seeds, a plain run
     // re-ingests everything.
     let stampedVersion: string | null = null;
+    let stampedSwedishVersion: string | null = null;
     if (seedExists && options.refresh) {
       try {
-        stampedVersion = stampedVersionOf(JSON.parse(fs.readFileSync(outputPath, 'utf-8')));
+        const seedJson = JSON.parse(fs.readFileSync(outputPath, 'utf-8')) as unknown;
+        stampedVersion = stampedVersionOf(seedJson);
+        stampedSwedishVersion = stampedLanguageVersionsOf(seedJson)?.swe ?? null;
       } catch {
         stampedVersion = null; // unreadable seed: self-heal via refetch_unknown
+        stampedSwedishVersion = null;
       }
       const decision = decideFetch({ seedExists, refresh: true, stampedVersion });
       console.log(
@@ -580,14 +626,21 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
         fetchNumberToken: candidate.number_token,
         canonicalStatuteId: candidate.canonical_id,
         existingStampedVersion: stampedVersion,
+        existingStampedSwedishVersion: stampedSwedishVersion,
       });
-      if (outcome.decision === 'skip_current' || !outcome.written) {
+      consecutiveTransportFailures = 0;
+      if (outcome.decision === 'stale_upstream') {
+        report.stale_upstream.push(candidate.canonical_id);
+      } else if (outcome.decision === 'skip_current' || !outcome.written) {
         report.skipped_current += 1;
       } else {
         report.ingested += 1;
       }
       if (outcome.consolidationAbsent) {
         report.consolidation_absent.push(candidate.canonical_id);
+      }
+      if (outcome.contentAbsentFallback) {
+        report.content_absent_fallback.push(candidate.canonical_id);
       }
       if (outcome.swedish === 'omitted_not_available') {
         report.swedish_omitted.not_available.push(candidate.canonical_id);
@@ -604,18 +657,37 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
       });
       console.error(`  ERROR: ${message}`);
 
-      if (/HTTP 429/u.test(message)) {
+      const kind = classifyIngestFailure(message);
+      if (kind === 'rate_limited') {
         report.aborted_reason = `rate_limited_at_${candidate.canonical_id}`;
         console.error('  Aborting run due to Finlex rate limiting.');
+        flushReport();
         break;
+      }
+      if (kind === 'transport') {
+        consecutiveTransportFailures += 1;
+        if (consecutiveTransportFailures >= TRANSPORT_ABORT_THRESHOLD) {
+          // A sustained outage must stop the sweep: every further candidate
+          // costs full retry exhaustion (~16s) and accomplishes nothing.
+          report.aborted_reason = `transport_outage_at_${candidate.canonical_id}`;
+          console.error(
+            `  Aborting run: ${consecutiveTransportFailures} consecutive transport failures — ` +
+              'sustained outage, resume with the same command once connectivity returns.'
+          );
+          flushReport();
+          break;
+        }
+      } else {
+        consecutiveTransportFailures = 0;
       }
     }
 
+    flushReport();
     await delay(REQUEST_DELAY_MS);
   }
 
-  report.finished_at = new Date().toISOString();
-  fs.writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2), 'utf-8');
+  flushReport();
+  writeFileAtomicSync(REPORT_PATH, JSON.stringify(report, null, 2));
 
   console.log('');
   console.log('Bulk ingestion summary');
@@ -623,12 +695,15 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
   console.log(`  Skipped existing:      ${report.skipped_existing}`);
   console.log(`  Skipped current:       ${report.skipped_current}`);
   console.log(`  Consolidation absent:  ${report.consolidation_absent.length} (as-enacted original acquired)`);
+  console.log(`  ContentAbsent shells:  ${report.content_absent_fallback.length} (as-enacted fallback, stamped)`);
+  console.log(`  Stale upstream:        ${report.stale_upstream.length} (newer seed kept)`);
   console.log(`  Swedish omitted:       ${report.swedish_omitted.not_available.length} unavailable, ${report.swedish_omitted.version_mismatch.length} version-mismatch`);
   console.log(`  Failed:                ${report.failed}`);
   if (report.aborted_reason) {
     console.log(`  Aborted reason:        ${report.aborted_reason}`);
   }
-  console.log(`  Report:                ${REPORT_PATH}`);
+  console.log(`  Run report:            ${durableReportPath}`);
+  console.log(`  Report (latest):       ${REPORT_PATH}`);
   console.log(`  Manifest:              ${MANIFEST_PATH}`);
 
   if (report.failed > 0) {

--- a/scripts/ingest-finlex-bulk.ts
+++ b/scripts/ingest-finlex-bulk.ts
@@ -57,6 +57,12 @@ interface CLIOptions {
   resume: boolean;
   /** Version-keyed refresh of existing seeds (overrides --resume skipping). */
   refresh: boolean;
+  /**
+   * Candidates from data/seed/*.json instead of the remote catalogue list.
+   * A refresh sweep must walk the EXISTING corpus — list-driven candidates
+   * would silently expand it with every statute Finlex lists.
+   */
+  seedsOnly: boolean;
   refreshList: boolean;
   cacheOnly: boolean;
 }
@@ -172,6 +178,7 @@ function parseArgs(argv: string[]): CLIOptions {
     maxPages: 5000,
     resume: false,
     refresh: false,
+    seedsOnly: false,
     refreshList: false,
     cacheOnly: false,
   };
@@ -183,6 +190,8 @@ function parseArgs(argv: string[]): CLIOptions {
       options.resume = true;
     } else if (arg === '--refresh') {
       options.refresh = true;
+    } else if (arg === '--seeds-only') {
+      options.seedsOnly = true;
     } else if (arg === '--refresh-list') {
       options.refreshList = true;
     } else if (arg === '--cache-only') {
@@ -213,6 +222,8 @@ function parseArgs(argv: string[]): CLIOptions {
       console.log('  --resume             Skip statutes whose seed files already exist');
       console.log('  --refresh            Version-keyed refresh: refetch seeds whose stamped');
       console.log('                       consolidation is older than upstream; self-heal unstamped seeds');
+      console.log('  --seeds-only         Walk existing data/seed/*.json instead of the remote');
+      console.log('                       catalogue (no corpus expansion)');
       console.log('  --refresh-list       Force refresh list from Finlex API');
       console.log('  --cache-only         Use cached list only (no network calls)');
       console.log('  --max-pages <N>      Safety cap for paginated list loading');
@@ -405,6 +416,61 @@ function outputPathFor(candidate: StatuteCandidate): string {
   return path.resolve(SEED_DIR, `${candidate.canonical_number}_${candidate.year}.json`);
 }
 
+const NON_STATUTE_SEEDS = new Set(['eu-references.json']);
+
+/**
+ * Candidates from the existing seed corpus (--seeds-only). The fetch number
+ * token (which may carry a historical version suffix, e.g. '39-001') is
+ * recovered from the seed's stored expression URL when present.
+ */
+export function deriveSeedCandidates(seedDir: string): StatuteCandidate[] {
+  const candidates: StatuteCandidate[] = [];
+
+  for (const file of fs.readdirSync(seedDir)) {
+    if (!file.endsWith('.json') || file.startsWith('_') || NON_STATUTE_SEEDS.has(file)) continue;
+    const match = file.match(/^(\d+)_(\d{4})\.json$/u);
+    if (!match) continue;
+
+    const canonicalNumber = normalizeCanonicalNumberToken(match[1]);
+    const year = match[2];
+
+    let numberToken = canonicalNumber;
+    let sourceUri = '';
+    try {
+      const seed = JSON.parse(fs.readFileSync(path.join(seedDir, file), 'utf-8')) as {
+        url?: string;
+      };
+      const tokenMatch = (seed.url ?? '').match(
+        /\/act\/(?:statute|statute-consolidated)\/\d{4}\/([^/]+)\/[a-z]{3}@/u
+      );
+      if (tokenMatch) {
+        numberToken = tokenMatch[1];
+        sourceUri = seed.url ?? '';
+      }
+    } catch {
+      // Unreadable seed: keep the filename-derived token; the refresh run
+      // will rewrite the seed anyway (refetch_unknown).
+    }
+
+    candidates.push({
+      canonical_id: `${canonicalNumber}/${year}`,
+      canonical_number: canonicalNumber,
+      year,
+      number_token: numberToken,
+      version: parseVersion(numberToken),
+      source_uri: sourceUri,
+    });
+  }
+
+  candidates.sort((a, b) => {
+    const yearDiff = Number(a.year) - Number(b.year);
+    if (yearDiff !== 0) return yearDiff;
+    return Number(a.canonical_number) - Number(b.canonical_number);
+  });
+
+  return candidates;
+}
+
 function writeManifest(candidates: StatuteCandidate[]): void {
   const manifest = {
     generated_at: new Date().toISOString(),
@@ -432,21 +498,37 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
   console.log(`  limit:    ${options.limit ?? 'none'}`);
   console.log(`  resume:   ${options.resume ? 'yes' : 'no'}`);
   console.log(`  refresh:  ${options.refresh ? 'yes (version-keyed)' : 'no'}`);
+  console.log(`  scope:    ${options.seedsOnly ? 'existing seeds (--seeds-only)' : 'remote catalogue list'}`);
   console.log('');
 
-  const entries = await loadListEntries(options);
-  const allCandidates = selectCandidates(entries);
-  const selected = selectCandidates(entries, options.limit);
+  let allCandidates: StatuteCandidate[];
+  let selected: StatuteCandidate[];
+  let listEntryCount = 0;
+
+  if (options.seedsOnly) {
+    allCandidates = deriveSeedCandidates(SEED_DIR);
+    if (allCandidates.length === 0) {
+      throw new Error(`--seeds-only: no statute seeds found under ${SEED_DIR}`);
+    }
+    selected = options.limit !== undefined ? allCandidates.slice(0, options.limit) : allCandidates;
+  } else {
+    const entries = await loadListEntries(options);
+    listEntryCount = entries.length;
+    allCandidates = selectCandidates(entries);
+    selected = selectCandidates(entries, options.limit);
+  }
 
   fs.mkdirSync(SEED_DIR, { recursive: true });
   fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true });
-  writeManifest(selected);
+  if (!options.seedsOnly) {
+    writeManifest(selected);
+  }
 
   const report: IngestionReport = {
     started_at: startedAt,
     finished_at: startedAt,
     options,
-    list_entries: entries.length,
+    list_entries: listEntryCount,
     unique_candidates: allCandidates.length,
     selected_candidates: selected.length,
     ingested: 0,
@@ -458,7 +540,7 @@ export async function ingestFinlexBulk(argv: string[] = process.argv.slice(2)): 
     failures: [],
   };
 
-  console.log(`List entries loaded:      ${entries.length}`);
+  console.log(`List entries loaded:      ${listEntryCount}`);
   console.log(`Unique statute candidates: ${allCandidates.length}`);
   console.log(`Selected for ingestion:    ${selected.length}`);
   console.log('');

--- a/scripts/ingest-finlex.ts
+++ b/scripts/ingest-finlex.ts
@@ -39,6 +39,7 @@ import {
   assertCurrentConsolidation,
   buildIngestStamp,
   decideRewrite,
+  stampedVersionOf,
   type ContentAbsentStamp,
   type FetchDecision,
   type FinlexDocType,
@@ -165,11 +166,21 @@ export interface IngestFinlexOptions {
   forensicCacheDir?: string;
 }
 
+function readSeedJson(seedPath: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
+  } catch {
+    return null; // missing/torn seed: no stamp to read — self-heal semantics
+  }
+}
+
 export type SwedishOutcome =
   | 'consolidated'
   | 'original'
   | 'omitted_not_available'
   | 'omitted_version_mismatch'
+  /** Swedish expression fetched but parsed to zero provisions (empty shell). */
+  | 'omitted_content_absent'
   /** Seed already current — the Swedish expression was never requested. */
   | 'not_fetched';
 
@@ -437,6 +448,12 @@ async function fetchExpression(
     const cached = fs.readFileSync(originalCachePath, 'utf-8');
     try {
       parseVersionIdentity(cached);
+      // Head-only identity parsing accepts body-torn files (empirically: a
+      // 60%-truncated statute still parses with partial provisions). The
+      // closing root tag is the cheap whole-document integrity witness.
+      if (!cached.trimEnd().endsWith('</akomaNtoso>')) {
+        throw new Error('cache file does not end with </akomaNtoso> — truncated body');
+      }
       return cached;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -475,16 +492,40 @@ async function fetchExpression(
     const prefix = `${year}_${number}_${lang}@`;
     const currentCopy = `${prefix}${versionKey}.consolidated.xml`;
     fs.mkdirSync(opts.forensicDir, { recursive: true });
-    // Prune superseded forensic copies: keep exactly the version just fetched.
-    for (const file of fs.readdirSync(opts.forensicDir)) {
-      if (file.startsWith(prefix) && file.endsWith('.consolidated.xml') && file !== currentCopy) {
+    // Write FIRST, then prune to the NEWEST version per statute+language
+    // (round 3): in the stale_upstream case the just-fetched expression is
+    // OLDER than an existing audit copy — the newer copy (the XML the kept
+    // seed was built from) must survive, and a write failure must never
+    // leave zero copies.
+    writeFileAtomicSync(path.join(opts.forensicDir, currentCopy), body);
+    const versionOf = (file: string): string =>
+      file.slice(prefix.length, -'.consolidated.xml'.length);
+    const copies = fs
+      .readdirSync(opts.forensicDir)
+      .filter(f => f.startsWith(prefix) && f.endsWith('.consolidated.xml'));
+    const newest = copies.reduce((a, b) => {
+      const va = versionOf(a);
+      const vb = versionOf(b);
+      if (va === 'unversioned') return b;
+      if (vb === 'unversioned') return a;
+      return vb > va ? b : a;
+    });
+    for (const file of copies) {
+      if (file !== newest) {
         fs.unlinkSync(path.join(opts.forensicDir, file));
       }
     }
-    writeFileAtomicSync(path.join(opts.forensicDir, currentCopy), body);
   }
 
   return body;
+}
+
+function isContentAbsentBody(xml: string): boolean {
+  const body = /<body[\s>][\s\S]*?<\/body>/u.exec(xml)?.[0];
+  if (!body) return false;
+  if (!/<hcontainer[^>]*\bname="contentAbsent"/u.test(body)) return false;
+  // Substantive vocabulary in the body disqualifies the empty-shell reading.
+  return !/<(section|chapter|paragraph|subsection|article)[\s>]/u.test(body);
 }
 
 export function parseFinlexXml(xml: string, fallbackId: string): ParsedStatute {
@@ -516,10 +557,11 @@ export function parseFinlexXml(xml: string, fallbackId: string): ParsedStatute {
     category,
     provisions,
     // Finlex publishes some consolidations as explicit empty shells:
-    // <body><hcontainer name="contentAbsent"/></body>. Recognized vocabulary,
-    // surfaced so the caller can fall back EXPLICITLY instead of silently
-    // writing a hollow seed.
-    contentAbsent: /<hcontainer[^>]*\bname="contentAbsent"/u.test(xml),
+    // <body><hcontainer name="contentAbsent"/></body>. STRUCTURAL check
+    // (round 3): the marker must be inside the body AND the body must hold
+    // no substantive vocabulary — a marker elsewhere in the document must
+    // never reroute an extractor shape-gap into the silent fallback.
+    contentAbsent: isContentAbsentBody(xml),
   };
 }
 
@@ -580,7 +622,11 @@ export async function ingestFinlexStatute(
     forensicDir: options.forensicCacheDir ?? FORENSIC_CACHE_DIR,
     retryBackoffMs: options.retryBackoffMs,
   };
-  const stampedVersion = options.existingStampedVersion ?? null;
+  // The 404-confirm and stale-upstream guards key on the stamp. Callers may
+  // supply it, but the default is the TARGET SEED's own stamp — otherwise the
+  // guards are dead code on every path that forgets the option (the CLI
+  // single-statute entry steered operators onto exactly that path, round 3).
+  const stampedVersion = options.existingStampedVersion ?? stampedVersionOf(readSeedJson(targetPath));
 
   console.log('Finlex Data Ingestion');
   console.log(`  Statute: ${canonicalId}`);
@@ -615,8 +661,18 @@ export async function ingestFinlexStatute(
   }
 
   if (finXml === null) {
+    // No stamp to prove a consolidation existed — but the consolidated-404
+    // classification shapes the corpus (as-enacted cohort), so a single
+    // unretried 404 is not enough evidence either way: confirm once (round 3).
+    await politeDelay(delayMs);
+    finXml = await fetchExpression('statute-consolidated', year, fetchNumberToken, 'fin', 'latest', fetchOpts);
+  }
+
+  if (finXml === null) {
     consolidationAbsent = true;
-    console.log(`  No consolidated document for ${canonicalId} (404) — acquiring as-enacted original.`);
+    console.log(
+      `  No consolidated document for ${canonicalId} (404, confirmed by second probe) — acquiring as-enacted original.`
+    );
     await politeDelay(delayMs);
     finXml = await fetchExpression('statute', year, fetchNumberToken, 'fin', '', fetchOpts);
   }
@@ -774,9 +830,22 @@ export async function ingestFinlexStatute(
     }
   }
 
-  const svParsed = sweXml ? parseFinlexXml(sweXml, canonicalId) : null;
+  let svParsed = sweXml ? parseFinlexXml(sweXml, canonicalId) : null;
   if (svParsed) {
     assertBodyIdentity(svParsed, canonicalId, `Swedish expression ${sweIdentity?.expression_uri ?? 'unknown'}`);
+  }
+  // Zero-provision Swedish text must never be stamped as present (round 3):
+  // version equality alone proved nothing about CONTENT — an empty shell
+  // stamped 'consolidated' parks the seed as bilingual-complete forever.
+  if (svParsed && svParsed.provisions.length === 0) {
+    console.warn(
+      `  Warning: Swedish expression for ${canonicalId} parsed to ZERO provisions` +
+        `${svParsed.contentAbsent ? ' (contentAbsent shell)' : ''} — omitting Swedish text.`
+    );
+    svParsed = null;
+    sweXml = null;
+    sweIdentity = null;
+    swedish = 'omitted_content_absent';
   }
 
   const svByEid = new Map<string, FinlexProvision>(
@@ -853,7 +922,14 @@ export async function ingestFinlexStatute(
     in_force_date: lifecycle.date_entry_into_force ?? fiParsed.issuedDate,
     // Version-pinned expression URL — never the ambiguous-version form.
     url: `https://opendata.finlex.fi/finlex/avoindata/v1${finIdentity.expression_uri}`,
-    description: `Ingested from Finlex open data (${fiParsed.category ?? 'statute'})`,
+    // The repeal date must reach the downstream pipeline: build-db derives
+    // document validity via extractRepealDateFromDescription, which matches
+    // the 'Kumottu YYYY-MM-DD' convention (round 3 — _ingest.lifecycle alone
+    // is invisible to it, so repealed acts computed as in_force downstream).
+    description:
+      status === 'repealed' && lifecycle.date_in_force_end
+        ? `Ingested from Finlex open data (${fiParsed.category ?? 'statute'}). Kumottu ${lifecycle.date_in_force_end}`
+        : `Ingested from Finlex open data (${fiParsed.category ?? 'statute'})`,
     provisions,
     provision_versions: provisions.map(p => ({
       ...p,

--- a/scripts/ingest-finlex.ts
+++ b/scripts/ingest-finlex.ts
@@ -34,17 +34,31 @@ import {
 import {
   FINLEX_API_BASE,
   parseVersionIdentity,
+  parseLifecycle,
+  deriveSeedStatus,
   assertCurrentConsolidation,
   buildIngestStamp,
   decideRewrite,
+  type ContentAbsentStamp,
   type FetchDecision,
   type FinlexDocType,
   type IngestStamp,
+  type StatuteLifecycle,
   type VersionIdentity,
 } from './lib/finlex-version.js';
+import { writeFileAtomicSync } from './lib/fs-atomic.js';
 
 const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname);
 const SOURCE_CACHE_DIR = path.resolve(SCRIPT_DIR, '../data/source/finlex');
+/**
+ * Version-keyed forensic copies of fetched consolidated XML. Deliberately
+ * OUTSIDE data/source/finlex: that directory's contents are git-tracked
+ * corpus inputs, and forensic copies (one per statute per language per
+ * version) would bury them in hundreds of MB of write-only output.
+ * data/source-cache/ is gitignored.
+ */
+const FORENSIC_CACHE_DIR = path.resolve(SCRIPT_DIR, '../data/source-cache/finlex');
+const VERSION_TOKEN_RE = /^\d{8}$/u;
 
 interface DocumentSeed {
   id: string;
@@ -108,6 +122,8 @@ interface ParsedStatute {
   documentNumber?: string;
   category?: string;
   provisions: FinlexProvision[];
+  /** True when the body is an explicit empty shell (<hcontainer name="contentAbsent"/>). */
+  contentAbsent: boolean;
 }
 
 export interface IngestFinlexOptions {
@@ -134,6 +150,19 @@ export interface IngestFinlexOptions {
    * NOT rewritten (decision 'skip_current').
    */
   existingStampedVersion?: string | null;
+  /**
+   * Swedish consolidation version stamped on the existing seed
+   * (`_ingest.languages.swe.consolidation_version`). skip_current requires
+   * BOTH languages' stamped versions to match the fetched Finnish version —
+   * otherwise a seed written with Swedish omitted would park forever.
+   */
+  existingStampedSwedishVersion?: string | null;
+  /**
+   * Directory for version-keyed forensic copies of consolidated XML.
+   * Defaults to data/source-cache/finlex (gitignored — NEVER the tracked
+   * data/source/finlex corpus-input directory). Tests should pass a tmp dir.
+   */
+  forensicCacheDir?: string;
 }
 
 export type SwedishOutcome =
@@ -149,6 +178,8 @@ export interface IngestOutcome {
   written: boolean;
   /** True when upstream has no consolidated document (definitive 404) and the as-enacted original was used. */
   consolidationAbsent: boolean;
+  /** True when the consolidation exists upstream but is an empty contentAbsent shell — as-enacted text used, stamped. */
+  contentAbsentFallback: boolean;
   identity: VersionIdentity;
   swedish: SwedishOutcome;
 }
@@ -376,6 +407,7 @@ function extractProvisions(node: unknown, inheritedChapter: string | undefined, 
 interface FetchExpressionOptions {
   fetchImpl?: typeof fetch;
   cacheDir: string;
+  forensicDir: string;
   retryBackoffMs?: number[];
 }
 
@@ -385,10 +417,12 @@ interface FetchExpressionOptions {
  * THROW — they are never reported as "gone".
  *
  * Cache policy: original (as-enacted) expressions are immutable, so the
- * version-blind cache file may be read back. Consolidated expressions are
- * NEVER read from cache — a version-blind cache read is exactly the
- * stale-version pin this module exists to remove. Fetched consolidated XML is
- * written to a version-keyed file as a forensic copy only.
+ * version-blind cache file may be read back — but only after it VALIDATES
+ * (a truncated file from an interrupted run must self-heal via refetch, not
+ * fail every later run). Consolidated expressions are NEVER read from cache —
+ * a version-blind cache read is exactly the stale-version pin this module
+ * exists to remove. Fetched consolidated XML goes to a version-keyed forensic
+ * copy in the gitignored forensic dir; superseded versions are pruned.
  */
 async function fetchExpression(
   docType: FinlexDocType,
@@ -400,7 +434,17 @@ async function fetchExpression(
 ): Promise<string | null> {
   const originalCachePath = path.join(opts.cacheDir, `${year}_${number}_${lang}.xml`);
   if (docType === 'statute' && fs.existsSync(originalCachePath)) {
-    return fs.readFileSync(originalCachePath, 'utf-8');
+    const cached = fs.readFileSync(originalCachePath, 'utf-8');
+    try {
+      parseVersionIdentity(cached);
+      return cached;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `  Corrupt original-XML cache ${originalCachePath} (${message}) — removing it and refetching.`
+      );
+      fs.unlinkSync(originalCachePath);
+    }
   }
 
   const url = `${FINLEX_API_BASE}/${docType}/${year}/${number}/${lang}@${version}`;
@@ -423,17 +467,21 @@ async function fetchExpression(
   }
 
   const body = await res.text();
-  fs.mkdirSync(opts.cacheDir, { recursive: true });
   if (docType === 'statute') {
-    fs.writeFileSync(originalCachePath, body, 'utf-8');
+    writeFileAtomicSync(originalCachePath, body);
   } else {
     const identity = parseVersionIdentity(body);
     const versionKey = identity.version_number ?? 'unversioned';
-    fs.writeFileSync(
-      path.join(opts.cacheDir, `${year}_${number}_${lang}@${versionKey}.consolidated.xml`),
-      body,
-      'utf-8'
-    );
+    const prefix = `${year}_${number}_${lang}@`;
+    const currentCopy = `${prefix}${versionKey}.consolidated.xml`;
+    fs.mkdirSync(opts.forensicDir, { recursive: true });
+    // Prune superseded forensic copies: keep exactly the version just fetched.
+    for (const file of fs.readdirSync(opts.forensicDir)) {
+      if (file.startsWith(prefix) && file.endsWith('.consolidated.xml') && file !== currentCopy) {
+        fs.unlinkSync(path.join(opts.forensicDir, file));
+      }
+    }
+    writeFileAtomicSync(path.join(opts.forensicDir, currentCopy), body);
   }
 
   return body;
@@ -467,7 +515,28 @@ export function parseFinlexXml(xml: string, fallbackId: string): ParsedStatute {
     documentNumber: parseDocumentNumber(preface),
     category,
     provisions,
+    // Finlex publishes some consolidations as explicit empty shells:
+    // <body><hcontainer name="contentAbsent"/></body>. Recognized vocabulary,
+    // surfaced so the caller can fall back EXPLICITLY instead of silently
+    // writing a hollow seed.
+    contentAbsent: /<hcontainer[^>]*\bname="contentAbsent"/u.test(xml),
   };
+}
+
+/**
+ * Body-identity check (Dutch round-2 lesson, dutch-law 976c0ef): the served
+ * document's own preface identity must match the requested statute. Redirects
+ * are followed transparently, so without this check a mis-served body would
+ * be written under the requested statute's filename with the WRONG content.
+ */
+function assertBodyIdentity(parsed: ParsedStatute, canonicalId: string, label: string): void {
+  if (!parsed.documentNumber) return; // no preface docNumber upstream — nothing to compare
+  const served = normalizeCanonicalStatuteId(parsed.id);
+  if (served !== canonicalId) {
+    throw new Error(
+      `Body identity mismatch for ${label}: requested ${canonicalId} but upstream served ${served} — refusing to seed mis-served content`
+    );
+  }
 }
 
 function parseStatuteId(id: string): { number: string; year: string } {
@@ -508,8 +577,10 @@ export async function ingestFinlexStatute(
   const fetchOpts: FetchExpressionOptions = {
     fetchImpl: options.fetchImpl,
     cacheDir: options.cacheDir ?? SOURCE_CACHE_DIR,
+    forensicDir: options.forensicCacheDir ?? FORENSIC_CACHE_DIR,
     retryBackoffMs: options.retryBackoffMs,
   };
+  const stampedVersion = options.existingStampedVersion ?? null;
 
   console.log('Finlex Data Ingestion');
   console.log(`  Statute: ${canonicalId}`);
@@ -525,6 +596,24 @@ export async function ingestFinlexStatute(
   let consolidationAbsent = false;
   let finXml = await fetchExpression('statute-consolidated', year, fetchNumberToken, 'fin', 'latest', fetchOpts);
 
+  if (finXml === null && stampedVersion !== null && VERSION_TOKEN_RE.test(stampedVersion)) {
+    // The stamp PROVES a consolidation existed upstream. A single unretried
+    // 404 must not silently downgrade the seed to as-enacted text: confirm
+    // once, and treat a persistent 404 as a loud anomaly.
+    console.warn(
+      `  404 on statute-consolidated for ${canonicalId}, but the seed stamp (${stampedVersion}) proves a ` +
+        'consolidation existed — confirming before treating it as real.'
+    );
+    await politeDelay(delayMs);
+    finXml = await fetchExpression('statute-consolidated', year, fetchNumberToken, 'fin', 'latest', fetchOpts);
+    if (finXml === null) {
+      throw new Error(
+        `Consolidated expression for ${canonicalId} DISAPPEARED upstream (persistent 404, stamp ` +
+          `${stampedVersion} proves it existed) — anomaly; refusing the silent downgrade to as-enacted text`
+      );
+    }
+  }
+
   if (finXml === null) {
     consolidationAbsent = true;
     console.log(`  No consolidated document for ${canonicalId} (404) — acquiring as-enacted original.`);
@@ -538,37 +627,130 @@ export async function ingestFinlexStatute(
     );
   }
 
-  const finIdentity = parseVersionIdentity(finXml);
+  let finIdentity = parseVersionIdentity(finXml);
   if (!consolidationAbsent) {
     assertCurrentConsolidation(finIdentity);
   }
 
-  // Refresh short-circuit: when the stamped version PROVES the seed already
-  // holds this consolidation, keep the file untouched (no git churn).
-  const decision = decideRewrite({
-    stampedVersion: options.existingStampedVersion ?? null,
+  // Refresh short-circuit and stale-upstream guard, keyed on the stamp.
+  let decision = decideRewrite({
+    stampedVersion,
     fetchedVersion: finIdentity.version_number,
   });
-  if (decision === 'skip_current' && fs.existsSync(targetPath)) {
-    console.log(`  Seed already at consolidation ${finIdentity.version_number} — skipping rewrite.`);
+  if (decision === 'stale_upstream') {
+    // fin@latest sits behind a ~10-min server-side cache; an expression older
+    // than the stamp is a realistic transient. The stamp proves newer text was
+    // already acquired — keep it, surface the anomaly, never rewrite backwards.
+    if (!fs.existsSync(targetPath)) {
+      throw new Error(
+        `Stale upstream for ${canonicalId} (fetched ${finIdentity.version_number}, stamped ${stampedVersion}) ` +
+          'with no local seed file — inconsistent caller state, refusing to write the older expression'
+      );
+    }
+    console.warn(
+      `  STALE UPSTREAM for ${canonicalId}: fetched consolidation ${finIdentity.version_number} is OLDER than ` +
+        `the stamped ${stampedVersion} — keeping the newer seed untouched.`
+    );
     return {
       decision,
       written: false,
       consolidationAbsent,
+      contentAbsentFallback: false,
       identity: finIdentity,
       swedish: 'not_fetched',
     };
   }
+  // skip_current requires BOTH languages to be proven current: a seed whose
+  // Swedish text was omitted (no swe stamp) must be re-examined — the Swedish
+  // consolidation may have caught up since.
+  if (decision === 'skip_current') {
+    if (
+      fs.existsSync(targetPath) &&
+      (options.existingStampedSwedishVersion ?? null) === finIdentity.version_number
+    ) {
+      console.log(
+        `  Seed already at consolidation ${finIdentity.version_number} (both languages) — skipping rewrite.`
+      );
+      return {
+        decision,
+        written: false,
+        consolidationAbsent,
+        contentAbsentFallback: false,
+        identity: finIdentity,
+        swedish: 'not_fetched',
+      };
+    }
+    if (fs.existsSync(targetPath)) {
+      console.log(
+        `  Finnish text already at ${finIdentity.version_number}, but the Swedish stamp does not match — ` +
+          're-examining the Swedish expression.'
+      );
+      decision = 'refetch_check';
+    } else {
+      decision = 'refetch_unknown'; // stamped current but the seed file is missing — rebuild it
+    }
+  }
 
-  // 2. Acquire Swedish text at the SAME version discipline. A Swedish
+  // 2. Parse the Finnish text and apply the zero-provision gate: a document
+  //    that parses to zero provisions must never become a seed. The ONLY
+  //    recognized empty shape is Finlex's explicit contentAbsent shell, which
+  //    triggers a stamped fallback to the as-enacted original; anything else
+  //    fails loud (unknown vocabulary/shape).
+  let fiParsed = parseFinlexXml(finXml, canonicalId);
+  // Lifecycle facts for the status: from the document that CARRIES them — the
+  // consolidated expression (or shell). As-enacted originals publish none.
+  let lifecycle: StatuteLifecycle = parseLifecycle(finXml);
+  let lifecycleDocType: FinlexDocType = finIdentity.doc_type;
+  let contentAbsentStamp: ContentAbsentStamp | undefined;
+
+  if (fiParsed.provisions.length === 0) {
+    if (!consolidationAbsent && fiParsed.contentAbsent) {
+      console.warn(
+        `  Consolidation ${finIdentity.version_number ?? 'unversioned'} for ${canonicalId} is an EMPTY ` +
+          'contentAbsent shell — explicit fallback to the as-enacted original (stamped as such).'
+      );
+      contentAbsentStamp = {
+        version: finIdentity.version_number,
+        consolidated_to: finIdentity.consolidated_to,
+      };
+      await politeDelay(delayMs);
+      const originalXml = await fetchExpression('statute', year, fetchNumberToken, 'fin', '', fetchOpts);
+      if (originalXml === null) {
+        throw new Error(
+          `Statute ${canonicalId}: consolidated expression is a contentAbsent shell AND the as-enacted ` +
+            'original is gone (404) — nothing real to seed, failing loud'
+        );
+      }
+      finXml = originalXml;
+      finIdentity = parseVersionIdentity(finXml);
+      fiParsed = parseFinlexXml(finXml, canonicalId);
+      if (fiParsed.provisions.length === 0) {
+        throw new Error(
+          `Statute ${canonicalId}: zero provisions in BOTH the consolidated shell and the as-enacted ` +
+            'original — refusing to write a hollow seed'
+        );
+      }
+    } else {
+      throw new Error(
+        `Statute ${canonicalId}: document ${finIdentity.expression_uri} parsed to ZERO provisions without a ` +
+          'recognized contentAbsent marker — unknown document shape, refusing to write a hollow seed'
+      );
+    }
+  }
+
+  assertBodyIdentity(fiParsed, canonicalId, `Finnish expression ${finIdentity.expression_uri}`);
+
+  // 3. Acquire Swedish text at the SAME version discipline. A Swedish
   //    consolidation at a different version is omitted (loudly) rather than
-  //    silently paired with Finnish text from another point in time.
+  //    silently paired with Finnish text from another point in time. When the
+  //    Finnish text is the as-enacted original (consolidated 404 or
+  //    contentAbsent shell), Swedish pairs with the as-enacted original too.
   let sweXml: string | null = null;
   let sweIdentity: VersionIdentity | null = null;
   let swedish: SwedishOutcome = 'omitted_not_available';
 
   await politeDelay(delayMs);
-  if (consolidationAbsent) {
+  if (consolidationAbsent || contentAbsentStamp) {
     sweXml = await fetchExpression('statute', year, fetchNumberToken, 'swe', '', fetchOpts);
     if (sweXml !== null) {
       sweIdentity = parseVersionIdentity(sweXml);
@@ -592,8 +774,10 @@ export async function ingestFinlexStatute(
     }
   }
 
-  const fiParsed = parseFinlexXml(finXml, canonicalId);
   const svParsed = sweXml ? parseFinlexXml(sweXml, canonicalId) : null;
+  if (svParsed) {
+    assertBodyIdentity(svParsed, canonicalId, `Swedish expression ${sweIdentity?.expression_uri ?? 'unknown'}`);
+  }
 
   const svByEid = new Map<string, FinlexProvision>(
     (svParsed?.provisions ?? []).map(p => [p.eId, p])
@@ -642,22 +826,38 @@ export async function ingestFinlexStatute(
     languages.swe = sweIdentity;
   }
 
+  // Status is a FACT from upstream lifecycle metadata (finlex:isInForce,
+  // dateInForceEnd, repealedBy), never a constant. For a contentAbsent shell
+  // the SHELL carries the authoritative lifecycle even though the text comes
+  // from the as-enacted original. As-enacted originals without lifecycle
+  // metadata get the documented default, stamped as unverified.
+  const { status, basis: statusBasis } = deriveSeedStatus({
+    docType: lifecycleDocType,
+    lifecycle,
+  });
+
+  // Validity claim for the served text: a consolidation proves its wording as
+  // of dateConsolidated — claiming validity from the original enactment date
+  // would assert amended/inserted provisions existed before they did. The
+  // as-enacted original proves its wording from enactment.
+  const textValidFrom = finIdentity.consolidated_to ?? fiParsed.issuedDate;
+
   const seed: DocumentSeed = {
     id: normalizedParsedId || canonicalId,
     type: 'statute',
     title: fiParsed.title,
     title_en: svParsed?.title,
     short_name: SHORT_NAME_BY_ID[normalizedParsedId] ?? SHORT_NAME_BY_ID[canonicalId],
-    status: 'in_force',
+    status,
     issued_date: fiParsed.issuedDate,
-    in_force_date: fiParsed.issuedDate,
+    in_force_date: lifecycle.date_entry_into_force ?? fiParsed.issuedDate,
     // Version-pinned expression URL — never the ambiguous-version form.
     url: `https://opendata.finlex.fi/finlex/avoindata/v1${finIdentity.expression_uri}`,
     description: `Ingested from Finlex open data (${fiParsed.category ?? 'statute'})`,
     provisions,
     provision_versions: provisions.map(p => ({
       ...p,
-      valid_from: fiParsed.issuedDate,
+      valid_from: textValidFrom,
       valid_to: null,
     })),
     definitions: definitions.length > 0 ? definitions : undefined,
@@ -666,6 +866,9 @@ export async function ingestFinlexStatute(
       now: new Date().toISOString(),
       primary: finIdentity,
       languages,
+      lifecycle,
+      statusBasis,
+      consolidatedContentAbsent: contentAbsentStamp,
     }),
   };
 
@@ -675,6 +878,7 @@ export async function ingestFinlexStatute(
 
   console.log(`  Source expression:      ${finIdentity.expression_uri}`);
   console.log(`  Consolidation version:  ${finIdentity.version_number ?? 'none (as-enacted original)'}`);
+  console.log(`  Status:                 ${status} (${statusBasis})`);
   console.log(`  Swedish text:           ${swedish}`);
   console.log(`  Parsed provisions (FI): ${fiParsed.provisions.length}`);
   console.log(`  Parsed provisions (SV): ${svParsed?.provisions.length ?? 0}`);
@@ -682,7 +886,14 @@ export async function ingestFinlexStatute(
   console.log(`  Preparatory refs:       ${preparatoryWorks.length}`);
   console.log(written ? `\n✅ Wrote seed file: ${targetPath}` : `\n✅ Seed unchanged: ${targetPath}`);
 
-  return { decision, written, consolidationAbsent, identity: finIdentity, swedish };
+  return {
+    decision,
+    written,
+    consolidationAbsent,
+    contentAbsentFallback: contentAbsentStamp !== undefined,
+    identity: finIdentity,
+    swedish,
+  };
 }
 
 /** Serialize without the volatile retrieval timestamp, for change detection. */
@@ -702,12 +913,27 @@ function writeSeedUnlessUnchanged(targetPath: string, seed: DocumentSeed): boole
       if (canonicalSeedJson(existing) === canonicalSeedJson(seed)) {
         return false;
       }
-    } catch {
+      // Last-line tripwire (defense in depth behind the zero-provision gate):
+      // a seed holding real provisions must NEVER be replaced by an empty one.
+      const existingProvisions = (existing as { provisions?: unknown[] }).provisions;
+      if (
+        Array.isArray(existingProvisions) &&
+        existingProvisions.length > 0 &&
+        (seed.provisions?.length ?? 0) === 0
+      ) {
+        throw new Error(
+          `Refusing to overwrite ${targetPath}: existing seed has ${existingProvisions.length} provisions, ` +
+            'replacement has zero — hollow overwrite blocked'
+        );
+      }
+    } catch (error) {
+      if (error instanceof Error && /hollow overwrite blocked/u.test(error.message)) {
+        throw error;
+      }
       // Unreadable/corrupt existing seed: overwrite it.
     }
   }
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.writeFileSync(targetPath, JSON.stringify(seed, null, 2), 'utf-8');
+  writeFileAtomicSync(targetPath, JSON.stringify(seed, null, 2));
   return true;
 }
 

--- a/scripts/ingest-finlex.ts
+++ b/scripts/ingest-finlex.ts
@@ -5,6 +5,13 @@
  * Fetches Finnish statutes from Finlex open data (Akoma Ntoso XML) and converts
  * them to seed JSON format for reproducible `build:db` runs.
  *
+ * Version discipline (issue #78): the acquisition fetches the CURRENT
+ * consolidation (act/statute-consolidated/{y}/{n}/{lang}@latest, ELI ajantasa)
+ * and stamps the seed with the version identity (`_ingest`). The original
+ * as-enacted expression (act/statute/{y}/{n}/{lang}@, ELI alkup) is used only
+ * when upstream answers a definitive 404 for the consolidated document — and
+ * that, too, is stamped. See scripts/lib/finlex-version.ts for the semantics.
+ *
  * Usage:
  *   npm run ingest -- <statute-id> [output-path]
  *
@@ -16,13 +23,26 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
-import { execFileSync } from 'child_process';
 import { XMLParser } from 'fast-xml-parser';
 import { foldNordicText, normalizeLegalText } from '../src/utils/legal-normalization.js';
+import {
+  fetchWithRetry,
+  politeDelay,
+  FINLEX_REQUEST_DELAY_MS,
+  FINLEX_USER_AGENT,
+} from './lib/finlex-http.js';
+import {
+  FINLEX_API_BASE,
+  parseVersionIdentity,
+  assertCurrentConsolidation,
+  buildIngestStamp,
+  decideRewrite,
+  type FetchDecision,
+  type FinlexDocType,
+  type IngestStamp,
+  type VersionIdentity,
+} from './lib/finlex-version.js';
 
-const FINLEX_BASE = 'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute';
-const USER_AGENT = 'Finnish-Law-MCP/1.2.2 (https://github.com/Ansvar-Systems/finnish-law-mcp)';
-const REQUEST_DELAY_MS = 250;
 const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname);
 const SOURCE_CACHE_DIR = path.resolve(SCRIPT_DIR, '../data/source/finlex');
 
@@ -41,6 +61,8 @@ interface DocumentSeed {
   provision_versions?: ProvisionVersionSeed[];
   definitions?: DefinitionSeed[];
   preparatory_works?: PrepWorkSeed[];
+  /** Version identity of the upstream expression this seed was built from (issue #78). */
+  _ingest?: IngestStamp;
 }
 
 interface ProvisionSeed {
@@ -75,6 +97,8 @@ interface FinlexProvision {
   section: string;
   title?: string;
   content: string;
+  /** Amending statute label from finlex:originalVersionLabel, e.g. '27.11.2020/902'. */
+  amendedBy?: string;
 }
 
 interface ParsedStatute {
@@ -96,6 +120,37 @@ export interface IngestFinlexOptions {
    * Optional override for canonical statute id written to seed file.
    */
   canonicalStatuteId?: string;
+  /** Injectable fetch (tests). Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Politeness delay between Finlex requests. Defaults to FINLEX_REQUEST_DELAY_MS (2s). */
+  delayMs?: number;
+  /** Source XML cache directory. Defaults to data/source/finlex. */
+  cacheDir?: string;
+  /** Retry backoff override (tests). */
+  retryBackoffMs?: number[];
+  /**
+   * Consolidation version stamped on the existing seed (`_ingest.consolidation_version`),
+   * passed by refresh callers. When the fetched version equals it, the seed is
+   * NOT rewritten (decision 'skip_current').
+   */
+  existingStampedVersion?: string | null;
+}
+
+export type SwedishOutcome =
+  | 'consolidated'
+  | 'original'
+  | 'omitted_not_available'
+  | 'omitted_version_mismatch'
+  /** Seed already current — the Swedish expression was never requested. */
+  | 'not_fetched';
+
+export interface IngestOutcome {
+  decision: FetchDecision;
+  written: boolean;
+  /** True when upstream has no consolidated document (definitive 404) and the as-enacted original was used. */
+  consolidationAbsent: boolean;
+  identity: VersionIdentity;
+  swedish: SwedishOutcome;
 }
 
 const SHORT_NAME_BY_ID: Record<string, string> = {
@@ -104,10 +159,6 @@ const SHORT_NAME_BY_ID: Record<string, string> = {
   '434/2003': 'Hallintolaki',
   '39/1889': 'Rikoslaki',
 };
-
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
 
 function asArray<T>(value: T | T[] | undefined): T[] {
   if (value === undefined || value === null) return [];
@@ -302,12 +353,17 @@ function extractProvisions(node: unknown, inheritedChapter: string | undefined, 
     const content = normalizeProvisionContent(contentParts.join('\n'));
     if (!content) continue;
 
+    const amendedBy = typeof sectionNode['@_finlex:originalVersionLabel'] === 'string'
+      ? (sectionNode['@_finlex:originalVersionLabel'] as string)
+      : undefined;
+
     out.push({
       eId,
       chapter: inheritedChapter,
       section,
       title,
       content,
+      amendedBy,
     });
   }
 
@@ -317,64 +373,73 @@ function extractProvisions(node: unknown, inheritedChapter: string | undefined, 
   }
 }
 
-async function fetchXml(year: string, number: string, lang: 'fin' | 'swe'): Promise<string | null> {
-  const cachePath = path.join(SOURCE_CACHE_DIR, `${year}_${number}_${lang}.xml`);
-  if (fs.existsSync(cachePath)) {
-    return fs.readFileSync(cachePath, 'utf-8');
-  }
-
-  const url = `${FINLEX_BASE}/${year}/${number}/${lang}@`;
-  const maxAttempts = 4;
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const raw = execFileSync(
-        'curl',
-        [
-          '-sS',
-          '-L',
-          '-A',
-          USER_AGENT,
-          '-H',
-          'Accept: application/xml,text/xml',
-          '-w',
-          '\n%{http_code}',
-          url,
-        ],
-        { encoding: 'utf-8' }
-      );
-
-      const splitAt = raw.lastIndexOf('\n');
-      if (splitAt === -1) {
-        throw new Error(`Unexpected curl response for ${url}`);
-      }
-
-      const body = raw.slice(0, splitAt);
-      const statusCode = Number(raw.slice(splitAt + 1).trim());
-
-      if (statusCode === 404) {
-        return null;
-      }
-      if (!Number.isFinite(statusCode) || statusCode >= 400) {
-        throw new Error(`HTTP ${statusCode} for ${url}`);
-      }
-
-      fs.mkdirSync(SOURCE_CACHE_DIR, { recursive: true });
-      fs.writeFileSync(cachePath, body, 'utf-8');
-
-      return body;
-    } catch (error) {
-      if (attempt === maxAttempts) {
-        throw error;
-      }
-      await delay(REQUEST_DELAY_MS * attempt);
-    }
-  }
-
-  return null;
+interface FetchExpressionOptions {
+  fetchImpl?: typeof fetch;
+  cacheDir: string;
+  retryBackoffMs?: number[];
 }
 
-function parseFinlexXml(xml: string, fallbackId: string): ParsedStatute {
+/**
+ * Fetch one AKN expression. Returns null ONLY on a definitive upstream 404;
+ * transient failures (5xx/429/network) retry inside fetchWithRetry and then
+ * THROW — they are never reported as "gone".
+ *
+ * Cache policy: original (as-enacted) expressions are immutable, so the
+ * version-blind cache file may be read back. Consolidated expressions are
+ * NEVER read from cache — a version-blind cache read is exactly the
+ * stale-version pin this module exists to remove. Fetched consolidated XML is
+ * written to a version-keyed file as a forensic copy only.
+ */
+async function fetchExpression(
+  docType: FinlexDocType,
+  year: string,
+  number: string,
+  lang: 'fin' | 'swe',
+  version: 'latest' | '',
+  opts: FetchExpressionOptions
+): Promise<string | null> {
+  const originalCachePath = path.join(opts.cacheDir, `${year}_${number}_${lang}.xml`);
+  if (docType === 'statute' && fs.existsSync(originalCachePath)) {
+    return fs.readFileSync(originalCachePath, 'utf-8');
+  }
+
+  const url = `${FINLEX_API_BASE}/${docType}/${year}/${number}/${lang}@${version}`;
+  const res = await fetchWithRetry(url, {
+    fetchImpl: opts.fetchImpl,
+    backoffMs: opts.retryBackoffMs,
+    headers: {
+      'User-Agent': FINLEX_USER_AGENT,
+      Accept: 'application/xml,text/xml',
+    },
+  });
+
+  if (res.status === 404) {
+    return null;
+  }
+  if (!res.ok) {
+    // fetchWithRetry only returns non-retryable 4xx here; anything but 404 is
+    // a contract violation worth failing loud on.
+    throw new Error(`HTTP ${res.status} for ${url}`);
+  }
+
+  const body = await res.text();
+  fs.mkdirSync(opts.cacheDir, { recursive: true });
+  if (docType === 'statute') {
+    fs.writeFileSync(originalCachePath, body, 'utf-8');
+  } else {
+    const identity = parseVersionIdentity(body);
+    const versionKey = identity.version_number ?? 'unversioned';
+    fs.writeFileSync(
+      path.join(opts.cacheDir, `${year}_${number}_${lang}@${versionKey}.consolidated.xml`),
+      body,
+      'utf-8'
+    );
+  }
+
+  return body;
+}
+
+export function parseFinlexXml(xml: string, fallbackId: string): ParsedStatute {
   const parser = new XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: '@_',
@@ -429,7 +494,7 @@ export async function ingestFinlexStatute(
   statuteId: string,
   outputPath?: string,
   options: IngestFinlexOptions = {}
-): Promise<void> {
+): Promise<IngestOutcome> {
   const { number, year } = parseStatuteId(statuteId);
   const canonicalNumber = normalizeCanonicalNumberToken(number);
   const canonicalId = options.canonicalStatuteId
@@ -439,6 +504,12 @@ export async function ingestFinlexStatute(
   const targetPath = outputPath
     ? path.resolve(outputPath)
     : path.resolve(SCRIPT_DIR, `../data/seed/${canonicalNumber}_${year}.json`);
+  const delayMs = options.delayMs ?? FINLEX_REQUEST_DELAY_MS;
+  const fetchOpts: FetchExpressionOptions = {
+    fetchImpl: options.fetchImpl,
+    cacheDir: options.cacheDir ?? SOURCE_CACHE_DIR,
+    retryBackoffMs: options.retryBackoffMs,
+  };
 
   console.log('Finlex Data Ingestion');
   console.log(`  Statute: ${canonicalId}`);
@@ -448,19 +519,77 @@ export async function ingestFinlexStatute(
   console.log(`  Output:  ${targetPath}`);
   console.log('');
 
-  const finXml = await fetchXml(year, fetchNumberToken, 'fin');
+  // 1. Acquire Finnish text: newest consolidation first; the as-enacted
+  //    original ONLY on a definitive consolidated 404 (no consolidation
+  //    published — e.g. brand-new statutes). Both outcomes are stamped.
+  let consolidationAbsent = false;
+  let finXml = await fetchExpression('statute-consolidated', year, fetchNumberToken, 'fin', 'latest', fetchOpts);
 
-  if (!finXml) {
-    throw new Error(`Could not fetch Finnish text for ${canonicalId} from Finlex.`);
+  if (finXml === null) {
+    consolidationAbsent = true;
+    console.log(`  No consolidated document for ${canonicalId} (404) — acquiring as-enacted original.`);
+    await politeDelay(delayMs);
+    finXml = await fetchExpression('statute', year, fetchNumberToken, 'fin', '', fetchOpts);
   }
 
+  if (finXml === null) {
+    throw new Error(
+      `Statute ${canonicalId} not found upstream: 404 for both statute-consolidated and statute expressions.`
+    );
+  }
+
+  const finIdentity = parseVersionIdentity(finXml);
+  if (!consolidationAbsent) {
+    assertCurrentConsolidation(finIdentity);
+  }
+
+  // Refresh short-circuit: when the stamped version PROVES the seed already
+  // holds this consolidation, keep the file untouched (no git churn).
+  const decision = decideRewrite({
+    stampedVersion: options.existingStampedVersion ?? null,
+    fetchedVersion: finIdentity.version_number,
+  });
+  if (decision === 'skip_current' && fs.existsSync(targetPath)) {
+    console.log(`  Seed already at consolidation ${finIdentity.version_number} — skipping rewrite.`);
+    return {
+      decision,
+      written: false,
+      consolidationAbsent,
+      identity: finIdentity,
+      swedish: 'not_fetched',
+    };
+  }
+
+  // 2. Acquire Swedish text at the SAME version discipline. A Swedish
+  //    consolidation at a different version is omitted (loudly) rather than
+  //    silently paired with Finnish text from another point in time.
   let sweXml: string | null = null;
-  try {
-    await delay(REQUEST_DELAY_MS);
-    sweXml = await fetchXml(year, fetchNumberToken, 'swe');
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`  Warning: Swedish version fetch failed for ${canonicalId}: ${message}`);
+  let sweIdentity: VersionIdentity | null = null;
+  let swedish: SwedishOutcome = 'omitted_not_available';
+
+  await politeDelay(delayMs);
+  if (consolidationAbsent) {
+    sweXml = await fetchExpression('statute', year, fetchNumberToken, 'swe', '', fetchOpts);
+    if (sweXml !== null) {
+      sweIdentity = parseVersionIdentity(sweXml);
+      swedish = 'original';
+    }
+  } else {
+    sweXml = await fetchExpression('statute-consolidated', year, fetchNumberToken, 'swe', 'latest', fetchOpts);
+    if (sweXml !== null) {
+      sweIdentity = parseVersionIdentity(sweXml);
+      if (sweIdentity.version_number !== finIdentity.version_number) {
+        console.warn(
+          `  Warning: Swedish consolidation ${sweIdentity.version_number ?? 'unversioned'} != ` +
+            `Finnish ${finIdentity.version_number ?? 'unversioned'} for ${canonicalId} — omitting Swedish text.`
+        );
+        sweXml = null;
+        sweIdentity = null;
+        swedish = 'omitted_version_mismatch';
+      } else {
+        swedish = 'consolidated';
+      }
+    }
   }
 
   const fiParsed = parseFinlexXml(finXml, canonicalId);
@@ -483,6 +612,10 @@ export async function ingestFinlexStatute(
       folded_fi: foldNordicText(provision.content),
     };
 
+    if (provision.amendedBy) {
+      metadata.amended_by = provision.amendedBy;
+    }
+
     if (sv) {
       metadata.title_sv = sv.title;
       metadata.content_sv = sv.content;
@@ -504,6 +637,11 @@ export async function ingestFinlexStatute(
   const preparatoryWorks = extractPreparatoryWorksFromContent(provisions);
   const normalizedParsedId = normalizeCanonicalStatuteId(fiParsed.id);
 
+  const languages: Record<string, VersionIdentity> = { fin: finIdentity };
+  if (sweIdentity) {
+    languages.swe = sweIdentity;
+  }
+
   const seed: DocumentSeed = {
     id: normalizedParsedId || canonicalId,
     type: 'statute',
@@ -513,7 +651,8 @@ export async function ingestFinlexStatute(
     status: 'in_force',
     issued_date: fiParsed.issuedDate,
     in_force_date: fiParsed.issuedDate,
-    url: `${FINLEX_BASE}/${year}/${fetchNumberToken}/fin@`,
+    // Version-pinned expression URL — never the ambiguous-version form.
+    url: `https://opendata.finlex.fi/finlex/avoindata/v1${finIdentity.expression_uri}`,
     description: `Ingested from Finlex open data (${fiParsed.category ?? 'statute'})`,
     provisions,
     provision_versions: provisions.map(p => ({
@@ -523,16 +662,53 @@ export async function ingestFinlexStatute(
     })),
     definitions: definitions.length > 0 ? definitions : undefined,
     preparatory_works: preparatoryWorks.length > 0 ? preparatoryWorks : undefined,
+    _ingest: buildIngestStamp({
+      now: new Date().toISOString(),
+      primary: finIdentity,
+      languages,
+    }),
   };
 
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.writeFileSync(targetPath, JSON.stringify(seed, null, 2), 'utf-8');
+  // Churn guard: when a refresh re-derives a byte-identical seed (everything
+  // but the retrieval timestamp), keep the existing file untouched.
+  const written = writeSeedUnlessUnchanged(targetPath, seed);
 
+  console.log(`  Source expression:      ${finIdentity.expression_uri}`);
+  console.log(`  Consolidation version:  ${finIdentity.version_number ?? 'none (as-enacted original)'}`);
+  console.log(`  Swedish text:           ${swedish}`);
   console.log(`  Parsed provisions (FI): ${fiParsed.provisions.length}`);
   console.log(`  Parsed provisions (SV): ${svParsed?.provisions.length ?? 0}`);
   console.log(`  Definitions extracted:  ${definitions.length}`);
   console.log(`  Preparatory refs:       ${preparatoryWorks.length}`);
-  console.log(`\n✅ Wrote seed file: ${targetPath}`);
+  console.log(written ? `\n✅ Wrote seed file: ${targetPath}` : `\n✅ Seed unchanged: ${targetPath}`);
+
+  return { decision, written, consolidationAbsent, identity: finIdentity, swedish };
+}
+
+/** Serialize without the volatile retrieval timestamp, for change detection. */
+function canonicalSeedJson(seed: unknown): string {
+  const clone = JSON.parse(JSON.stringify(seed)) as Record<string, unknown>;
+  const ingest = clone._ingest as Record<string, unknown> | undefined;
+  if (ingest) {
+    delete ingest.retrieved_at;
+  }
+  return JSON.stringify(clone);
+}
+
+function writeSeedUnlessUnchanged(targetPath: string, seed: DocumentSeed): boolean {
+  if (fs.existsSync(targetPath)) {
+    try {
+      const existing = JSON.parse(fs.readFileSync(targetPath, 'utf-8')) as unknown;
+      if (canonicalSeedJson(existing) === canonicalSeedJson(seed)) {
+        return false;
+      }
+    } catch {
+      // Unreadable/corrupt existing seed: overwrite it.
+    }
+  }
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, JSON.stringify(seed, null, 2), 'utf-8');
+  return true;
 }
 
 async function main(): Promise<void> {

--- a/scripts/ingest-relevant-laws.ts
+++ b/scripts/ingest-relevant-laws.ts
@@ -12,6 +12,20 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { ingest } from './ingest-riksdagen.js';
 
+// LEGACY GUARD (issue #78 round-2): Swedish-template leftover — writes
+// UNSTAMPED Riksdagen-sourced seeds into data/seed/, bypassing the
+// version-stamped Finlex acquisition. Refuses to run unless forced.
+if (process.env.FORCE_LEGACY_INGEST !== '1') {
+  console.error(
+    'REFUSING TO RUN: ingest-relevant-laws.ts is a LEGACY Swedish-template script ' +
+      '(Riksdagen API) that writes unstamped seeds into data/seed/, bypassing the ' +
+      'version-stamped Finlex acquisition (issue #78).\n' +
+      'Use `npm run ingest`, `npm run ingest:bulk`, or `npm run ingest:refresh` instead.\n' +
+      'Set FORCE_LEGACY_INGEST=1 to override (you almost certainly do not want this).'
+  );
+  process.exit(2);
+}
+
 interface RelevantStatute {
   id: string;
   slug: string;

--- a/scripts/lib/finlex-http.ts
+++ b/scripts/lib/finlex-http.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared HTTP helper for Finlex open-data acquisition (issue #78).
+ * Port of Dutch-law-mcp src/ingest/http-retry.ts (merged dutch-law#117/#120).
+ *
+ * Transient failures (5xx, 429, thrown network errors) retry with backoff and
+ * then THROW. They are never soft-failed to null or skipped, so a flaky
+ * network can never be recorded as "document gone upstream". Non-retryable
+ * client errors (404 and other 4xx) are returned for the caller to interpret:
+ * a 404 on a statute-consolidated fetch IS a finding (no consolidation
+ * published), not an error.
+ */
+
+export const FINLEX_USER_AGENT =
+  'Finnish-Law-MCP/1.2.3 (https://github.com/Ansvar-Systems/Finnish-law-mcp)';
+
+/** Politeness floor for requests against opendata.finlex.fi (>=2s per request). */
+export const FINLEX_REQUEST_DELAY_MS = 2000;
+
+const DEFAULT_BACKOFF_MS = [2_000, 4_000, 8_000];
+
+export function politeDelay(ms: number = FINLEX_REQUEST_DELAY_MS): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function fetchWithRetry(
+  url: string,
+  opts: {
+    fetchImpl?: typeof fetch;
+    attempts?: number;
+    backoffMs?: number[];
+    headers?: Record<string, string>;
+  } = {}
+): Promise<Response> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const attempts = opts.attempts ?? 4;
+  const backoff = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const headers = opts.headers ?? { 'User-Agent': FINLEX_USER_AGENT };
+  let lastProblem = 'unknown';
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const res = await fetchImpl(url, { redirect: 'follow', headers });
+      if (res.ok) return res;
+      if (res.status >= 500 || res.status === 429) {
+        lastProblem = `HTTP ${res.status}`;
+      } else {
+        return res; // non-retryable 4xx: the caller decides what it means
+      }
+    } catch (err) {
+      lastProblem = err instanceof Error ? err.message : String(err);
+    }
+    if (attempt < attempts) {
+      await politeDelay(backoff[Math.min(attempt - 1, backoff.length - 1)] ?? 0);
+    }
+  }
+  throw new Error(`fetch ${url} failed after ${attempts} attempts: ${lastProblem}`);
+}

--- a/scripts/lib/finlex-version.ts
+++ b/scripts/lib/finlex-version.ts
@@ -1,0 +1,253 @@
+/**
+ * Version identity + version-keyed refresh policy for the Finlex open-data
+ * acquisition (issue #78, port of dutch-law-mcp src/ingest/{toestand,refresh-policy}.ts).
+ *
+ * Finlex AKN version semantics (verified against the live API + OpenAPI spec,
+ * 2026-06-10):
+ *
+ *   - act/statute/{y}/{n}/{lang}@           -> ORIGINAL as-enacted text
+ *     (ELI alias .../alkup, <act contains="originalVersion">). This is the URL
+ *     the pre-fix pipeline used for the WHOLE corpus: every seed carried
+ *     as-enacted text, missing all later amendments.
+ *   - act/statute-consolidated/{y}/{n}/{lang}@{VER} -> consolidation
+ *     (ELI alias .../ajantasa). VER is YYYYNNNN: year + zero-padded number of
+ *     the newest amending statute incorporated. A BARE `@` on the consolidated
+ *     doctype resolves to the OLDEST expression, so it must never be used.
+ *   - {lang}@latest -> the NEWEST version (documented in the OpenAPI spec;
+ *     ~10 min server-side cache). This is the only safe acquisition token.
+ *
+ * Whenever freshness cannot be PROVEN (no stamp, unparseable values, upstream
+ * older than stamp) the policy refetches — never a silent skip.
+ */
+
+import { XMLParser } from 'fast-xml-parser';
+
+export const FINLEX_API_BASE = 'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act';
+
+export type FinlexDocType = 'statute' | 'statute-consolidated';
+
+export interface VersionIdentity {
+  /** Upstream document type the expression was actually served from. */
+  doc_type: FinlexDocType;
+  /** Version-pinned expression URI, e.g. '/akn/fi/act/statute-consolidated/2018/1050/fin@20260380'. */
+  expression_uri: string;
+  /** Consolidation version token (FRBRversionNumber, YYYYNNNN); null for as-enacted originals. */
+  version_number: string | null;
+  /** Point-in-time date of the consolidation (FRBRdate name="dateConsolidated"); null for originals. */
+  consolidated_to: string | null;
+  /** ELI alias of the expression (…/ajantasa/… or …/alkup/…). */
+  eli_uri: string | null;
+  /** ISO 639-2 language of the expression ('fin' / 'swe'). */
+  language: string;
+  /** AKN <act contains> attribute ('originalVersion' / 'multipleVersions' / 'singleVersion'). */
+  contains: string;
+}
+
+interface FrbrDateNode {
+  '@_date'?: string;
+  '@_name'?: string;
+}
+
+function asArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function attr(node: Record<string, unknown> | undefined, name: string): string | null {
+  const value = node?.[name];
+  return typeof value === 'string' ? value : null;
+}
+
+/**
+ * Extract the FRBR version identity from a Finlex AKN document.
+ * Throws when the identification block is missing or incomplete — a document
+ * whose version cannot be established must not be ingested.
+ */
+export function parseVersionIdentity(xml: string): VersionIdentity {
+  // The identification block sits in the first ~3KB; slice before parsing so
+  // multi-MB statute bodies are not parsed twice.
+  const start = xml.indexOf('<identification');
+  const end = xml.indexOf('</identification>');
+  if (start === -1 || end === -1) {
+    throw new Error('Finlex AKN document has no <identification> block — cannot establish version identity');
+  }
+  const containsMatch = xml.match(/<act\s[^>]*contains="([^"]+)"/u);
+
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+  const parsed = parser.parse(xml.slice(start, end + '</identification>'.length)) as Record<
+    string,
+    unknown
+  >;
+  const identification = parsed.identification as Record<string, unknown> | undefined;
+  const expression = identification?.FRBRExpression as Record<string, unknown> | undefined;
+  if (!expression) {
+    throw new Error('Finlex AKN identification block has no FRBRExpression — cannot establish version identity');
+  }
+
+  const expressionUri = attr(expression.FRBRuri as Record<string, unknown>, '@_value');
+  if (!expressionUri) {
+    throw new Error('FRBRExpression has no FRBRuri — cannot establish version identity');
+  }
+
+  const docTypeMatch = expressionUri.match(/\/act\/(statute-consolidated|statute)\//u);
+  if (!docTypeMatch) {
+    throw new Error(`FRBRExpression URI "${expressionUri}" is not a statute expression`);
+  }
+
+  const langAndVersion = expressionUri.match(/\/([a-z]{3})@([0-9a-zA-Z]*)$/u);
+  if (!langAndVersion) {
+    throw new Error(`FRBRExpression URI "${expressionUri}" has no {lang}@{version} segment`);
+  }
+
+  let consolidatedTo: string | null = null;
+  for (const dateNode of asArray(expression.FRBRdate as FrbrDateNode | FrbrDateNode[])) {
+    if (dateNode['@_name'] === 'dateConsolidated' && typeof dateNode['@_date'] === 'string') {
+      consolidatedTo = dateNode['@_date'];
+    }
+  }
+
+  let eliUri: string | null = null;
+  for (const alias of asArray(expression.FRBRalias as Record<string, unknown> | Record<string, unknown>[])) {
+    if (attr(alias, '@_name') === 'eli') {
+      eliUri = attr(alias, '@_value');
+    }
+  }
+
+  const versionNumber = attr(expression.FRBRversionNumber as Record<string, unknown>, '@_value');
+
+  return {
+    doc_type: docTypeMatch[1] as FinlexDocType,
+    expression_uri: expressionUri,
+    version_number: versionNumber,
+    consolidated_to: consolidatedTo,
+    eli_uri: eliUri,
+    language: langAndVersion[1],
+    contains: containsMatch?.[1] ?? 'unknown',
+  };
+}
+
+/**
+ * Defense against the issue-#78 defect class: refuse to treat an as-enacted
+ * (alkup) expression as the current consolidation.
+ */
+export function assertCurrentConsolidation(identity: VersionIdentity): void {
+  if (identity.doc_type !== 'statute-consolidated') {
+    throw new Error(
+      `Expected a consolidated (ajantasa) expression but got doc_type="${identity.doc_type}" ` +
+        `(${identity.expression_uri}) — original/alkup text must never be stamped as current`
+    );
+  }
+  if (identity.eli_uri && !identity.eli_uri.includes('/ajantasa')) {
+    throw new Error(
+      `Consolidated expression ${identity.expression_uri} carries a non-ajantasa ELI alias ` +
+        `(${identity.eli_uri}) — refusing to stamp it as the current consolidation`
+    );
+  }
+}
+
+const VERSION_TOKEN_RE = /^\d{8}$/u;
+
+/**
+ * Compare two YYYYNNNN consolidation tokens. Lexical order IS chronological
+ * order (fixed 8 digits; statute numbers are assigned chronologically within
+ * a year and zero-padded to 4 digits). Throws on malformed tokens.
+ */
+export function compareVersionNumbers(a: string, b: string): number {
+  if (!VERSION_TOKEN_RE.test(a) || !VERSION_TOKEN_RE.test(b)) {
+    throw new Error(`Malformed consolidation version token(s): "${a}" / "${b}" (expected YYYYNNNN)`);
+  }
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+export type FetchDecision =
+  | 'fetch_new'
+  | 'skip_existing'
+  | 'refetch_unknown'
+  | 'refetch_check'
+  | 'refetch_changed'
+  | 'skip_current';
+
+/**
+ * Pre-network decision. With Finlex the newest-version probe IS the document
+ * fetch (`fin@latest`), so a stamped seed in refresh mode resolves to
+ * 'refetch_check': fetch, then let decideRewrite() decide whether to write.
+ */
+export function decideFetch(opts: {
+  seedExists: boolean;
+  refresh: boolean;
+  stampedVersion: string | null;
+}): FetchDecision {
+  if (!opts.seedExists) return 'fetch_new';
+  if (!opts.refresh) return 'skip_existing';
+  // A seed without a consolidation stamp predates newest-version acquisition
+  // and may hold as-enacted content. Self-heal is unconditional.
+  if (!opts.stampedVersion || !VERSION_TOKEN_RE.test(opts.stampedVersion)) return 'refetch_unknown';
+  return 'refetch_check';
+}
+
+/**
+ * Post-fetch decision: rewrite the seed unless the stamp PROVES the seed
+ * already holds the fetched version.
+ */
+export function decideRewrite(opts: {
+  stampedVersion: string | null;
+  fetchedVersion: string | null;
+}): FetchDecision {
+  const stampedValid = opts.stampedVersion !== null && VERSION_TOKEN_RE.test(opts.stampedVersion);
+  const fetchedValid = opts.fetchedVersion !== null && VERSION_TOKEN_RE.test(opts.fetchedVersion);
+  if (!stampedValid || !fetchedValid) return 'refetch_unknown';
+  const cmp = compareVersionNumbers(opts.fetchedVersion as string, opts.stampedVersion as string);
+  if (cmp > 0) return 'refetch_changed';
+  if (cmp === 0) return 'skip_current';
+  return 'refetch_unknown';
+}
+
+export interface LanguageStamp {
+  expression_uri: string;
+  consolidation_version: string | null;
+}
+
+export interface IngestStamp {
+  retrieved_at: string;
+  source: 'finlex-opendata';
+  doc_type: FinlexDocType;
+  expression_uri: string;
+  consolidation_version: string | null;
+  consolidated_to: string | null;
+  eli_uri: string | null;
+  languages: Record<string, LanguageStamp>;
+}
+
+export function buildIngestStamp(opts: {
+  now: string;
+  primary: VersionIdentity;
+  languages: Record<string, VersionIdentity>;
+}): IngestStamp {
+  const languages: Record<string, LanguageStamp> = {};
+  for (const [lang, identity] of Object.entries(opts.languages)) {
+    languages[lang] = {
+      expression_uri: identity.expression_uri,
+      consolidation_version: identity.version_number,
+    };
+  }
+  return {
+    retrieved_at: opts.now,
+    source: 'finlex-opendata',
+    doc_type: opts.primary.doc_type,
+    expression_uri: opts.primary.expression_uri,
+    consolidation_version: opts.primary.version_number,
+    consolidated_to: opts.primary.consolidated_to,
+    eli_uri: opts.primary.eli_uri,
+    languages,
+  };
+}
+
+/** Read the stamped consolidation version from an existing seed file's parsed JSON. */
+export function stampedVersionOf(seed: unknown): string | null {
+  if (typeof seed !== 'object' || seed === null) return null;
+  const ingest = (seed as Record<string, unknown>)._ingest;
+  if (typeof ingest !== 'object' || ingest === null) return null;
+  const version = (ingest as Record<string, unknown>).consolidation_version;
+  return typeof version === 'string' ? version : null;
+}

--- a/scripts/lib/finlex-version.ts
+++ b/scripts/lib/finlex-version.ts
@@ -115,15 +115,177 @@ export function parseVersionIdentity(xml: string): VersionIdentity {
 
   const versionNumber = attr(expression.FRBRversionNumber as Record<string, unknown>, '@_value');
 
+  // Single-version consolidations are served with a BARE '@' FRBRuri — the
+  // ambiguous form this module's header forbids (a bare '@' on the
+  // consolidated doctype re-resolves to the OLDEST expression once a second
+  // version appears). The version number sits in the same identification
+  // block, so pin the identity: '…/fin@' + '20050045' addresses the exact
+  // expression that was served.
+  const pinnedExpressionUri =
+    versionNumber !== null && expressionUri.endsWith('@')
+      ? `${expressionUri}${versionNumber}`
+      : expressionUri;
+
   return {
     doc_type: docTypeMatch[1] as FinlexDocType,
-    expression_uri: expressionUri,
+    expression_uri: pinnedExpressionUri,
     version_number: versionNumber,
     consolidated_to: consolidatedTo,
     eli_uri: eliUri,
     language: langAndVersion[1],
     contains: containsMatch?.[1] ?? 'unknown',
   };
+}
+
+/**
+ * Lifecycle facts Finlex publishes in the <proprietary> block of consolidated
+ * expressions (finlex:isInForce, finlex:inForce, finlex:repealedBy).
+ * As-enacted (alkup) expressions carry none of these — `is_in_force` is null
+ * for them ("no fact published"), never a guessed boolean.
+ */
+export interface StatuteLifecycle {
+  /** finlex:isInForce value; null when upstream publishes no lifecycle metadata. */
+  is_in_force: boolean | null;
+  /** Top-level finlex:inForce/dateEntryIntoForce (NOT the nested per-amendment ones). */
+  date_entry_into_force: string | null;
+  /** finlex:inForce/dateInForceEnd — the day the act ceased to be in force. */
+  date_in_force_end: string | null;
+  /** Statute ids (e.g. '1050/2018') from finlex:repealedBy references. */
+  repealed_by: string[];
+}
+
+function refToStatuteId(ref: unknown): string | null {
+  if (typeof ref === 'string') return ref.trim();
+  if (typeof ref !== 'object' || ref === null) return null;
+  const node = ref as Record<string, unknown>;
+  const text = node['#text'];
+  if (typeof text === 'string' && text.trim()) return text.trim();
+  const href = node['@_href'];
+  if (typeof href === 'string') {
+    const match = href.match(/\/(\d{4})\/(\d+)$/u);
+    if (match) return `${match[2]}/${match[1]}`;
+  }
+  return null;
+}
+
+/**
+ * Parse the finlex lifecycle metadata from an AKN document. Reads only the
+ * TOP-LEVEL <proprietary> children — finlex:amendedBy / finlex:repealedBy
+ * statute references carry their own nested finlex:inForce blocks which must
+ * not be mistaken for the document's own lifecycle.
+ *
+ * Unknown isInForce vocabulary fails loud — a lifecycle value we cannot
+ * interpret must never silently become a status claim.
+ */
+export function parseLifecycle(xml: string): StatuteLifecycle {
+  const empty: StatuteLifecycle = {
+    is_in_force: null,
+    date_entry_into_force: null,
+    date_in_force_end: null,
+    repealed_by: [],
+  };
+
+  const start = xml.indexOf('<proprietary');
+  const end = xml.indexOf('</proprietary>');
+  if (start === -1 || end === -1) return empty;
+
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+  const parsed = parser.parse(xml.slice(start, end + '</proprietary>'.length)) as Record<
+    string,
+    unknown
+  >;
+  const proprietary = parsed.proprietary as Record<string, unknown> | undefined;
+  if (!proprietary) return empty;
+
+  let isInForce: boolean | null = null;
+  const isInForceNode = proprietary['finlex:isInForce'] as Record<string, unknown> | undefined;
+  const isInForceValue = attr(isInForceNode, '@_value');
+  if (isInForceNode !== undefined) {
+    if (isInForceValue === 'true') {
+      isInForce = true;
+    } else if (isInForceValue === 'false') {
+      isInForce = false;
+    } else {
+      throw new Error(
+        `Unknown finlex:isInForce value "${isInForceValue ?? '(none)'}" — refusing to derive a status from vocabulary drift`
+      );
+    }
+  }
+
+  let dateEntryIntoForce: string | null = null;
+  let dateInForceEnd: string | null = null;
+  for (const inForce of asArray(proprietary['finlex:inForce'] as Record<string, unknown> | Record<string, unknown>[])) {
+    const entry = asArray(inForce['finlex:dateEntryIntoForce'] as Record<string, unknown> | Record<string, unknown>[])[0];
+    const entryDate = attr(entry, '@_date');
+    if (entryDate) dateEntryIntoForce = entryDate;
+    const endNode = asArray(inForce['finlex:dateInForceEnd'] as Record<string, unknown> | Record<string, unknown>[])[0];
+    const endDate = attr(endNode, '@_date');
+    if (endDate) dateInForceEnd = endDate;
+  }
+
+  const repealedBy: string[] = [];
+  for (const block of asArray(proprietary['finlex:repealedBy'] as Record<string, unknown> | Record<string, unknown>[])) {
+    for (const reference of asArray(block['finlex:statuteReference'] as Record<string, unknown> | Record<string, unknown>[])) {
+      const id = refToStatuteId(reference['finlex:ref']);
+      if (id) repealedBy.push(id);
+    }
+  }
+
+  return {
+    is_in_force: isInForce,
+    date_entry_into_force: dateEntryIntoForce,
+    date_in_force_end: dateInForceEnd,
+    repealed_by: repealedBy,
+  };
+}
+
+export type SeedStatus = 'in_force' | 'amended' | 'repealed' | 'not_yet_in_force';
+
+export type StatusBasis = 'finlex_lifecycle_metadata' | 'as_enacted_default_unverified';
+
+/**
+ * Derive the seed status from upstream lifecycle facts.
+ *
+ *   - isInForce=true               -> in_force
+ *   - isInForce=false, future
+ *     entry-into-force date        -> not_yet_in_force
+ *   - isInForce=false otherwise    -> repealed (covers explicit repealedBy AND
+ *     expiry via dateInForceEnd — the seed schema has no 'expired' value; the
+ *     precise facts are preserved in the _ingest.lifecycle stamp)
+ *   - no lifecycle on a CONSOLIDATED document -> throw (every probed
+ *     consolidated expression carries finlex:isInForce; absence is shape
+ *     drift, not a fact)
+ *   - no lifecycle on an AS-ENACTED document -> 'in_force' stamped
+ *     'as_enacted_default_unverified'. Finlex publishes no machine-readable
+ *     lifecycle state on alkup expressions, and statutes without a
+ *     consolidated counterpart (~60% of the corpus: amendment acts, treaty
+ *     implementation acts) have no other upstream signal. The default keeps
+ *     the corpus serving; the stamped basis makes the unverified claim
+ *     auditable instead of indistinguishable from a proven fact.
+ */
+export function deriveSeedStatus(opts: {
+  docType: FinlexDocType;
+  lifecycle: StatuteLifecycle;
+  /** ISO date used for the not_yet_in_force comparison; defaults to today. */
+  today?: string;
+}): { status: SeedStatus; basis: StatusBasis } {
+  const { docType, lifecycle } = opts;
+  if (lifecycle.is_in_force === null) {
+    if (docType === 'statute-consolidated') {
+      throw new Error(
+        'Consolidated expression carries no finlex:isInForce lifecycle metadata — shape drift, refusing to invent a status'
+      );
+    }
+    return { status: 'in_force', basis: 'as_enacted_default_unverified' };
+  }
+  if (lifecycle.is_in_force) {
+    return { status: 'in_force', basis: 'finlex_lifecycle_metadata' };
+  }
+  const today = opts.today ?? new Date().toISOString().slice(0, 10);
+  if (lifecycle.date_entry_into_force !== null && lifecycle.date_entry_into_force > today) {
+    return { status: 'not_yet_in_force', basis: 'finlex_lifecycle_metadata' };
+  }
+  return { status: 'repealed', basis: 'finlex_lifecycle_metadata' };
 }
 
 /**
@@ -166,7 +328,9 @@ export type FetchDecision =
   | 'refetch_unknown'
   | 'refetch_check'
   | 'refetch_changed'
-  | 'skip_current';
+  | 'skip_current'
+  /** Upstream served an expression OLDER than the stamp — keep the newer seed. */
+  | 'stale_upstream';
 
 /**
  * Pre-network decision. With Finlex the newest-version probe IS the document
@@ -188,7 +352,10 @@ export function decideFetch(opts: {
 
 /**
  * Post-fetch decision: rewrite the seed unless the stamp PROVES the seed
- * already holds the fetched version.
+ * already holds the fetched version. A fetched expression OLDER than the
+ * stamp is a stale-upstream anomaly (fin@latest sits behind a ~10-min
+ * server-side cache): the stamp proves a newer consolidation was served
+ * before, so rewriting would destroy newer text — refuse and surface it.
  */
 export function decideRewrite(opts: {
   stampedVersion: string | null;
@@ -200,12 +367,18 @@ export function decideRewrite(opts: {
   const cmp = compareVersionNumbers(opts.fetchedVersion as string, opts.stampedVersion as string);
   if (cmp > 0) return 'refetch_changed';
   if (cmp === 0) return 'skip_current';
-  return 'refetch_unknown';
+  return 'stale_upstream';
 }
 
 export interface LanguageStamp {
   expression_uri: string;
   consolidation_version: string | null;
+}
+
+/** Consolidated shell published with an empty body (<hcontainer name="contentAbsent"/>). */
+export interface ContentAbsentStamp {
+  version: string | null;
+  consolidated_to: string | null;
 }
 
 export interface IngestStamp {
@@ -217,12 +390,25 @@ export interface IngestStamp {
   consolidated_to: string | null;
   eli_uri: string | null;
   languages: Record<string, LanguageStamp>;
+  /** Upstream lifecycle facts the seed status was derived from. */
+  lifecycle?: StatuteLifecycle;
+  /** How the seed status was established (proven fact vs documented default). */
+  status_basis?: StatusBasis;
+  /**
+   * Set when the consolidated expression exists upstream but its body is an
+   * empty contentAbsent shell: the seed text is the as-enacted original, used
+   * as an EXPLICIT, stamped fallback (never a silent overwrite with nothing).
+   */
+  consolidated_content_absent?: ContentAbsentStamp;
 }
 
 export function buildIngestStamp(opts: {
   now: string;
   primary: VersionIdentity;
   languages: Record<string, VersionIdentity>;
+  lifecycle?: StatuteLifecycle;
+  statusBasis?: StatusBasis;
+  consolidatedContentAbsent?: ContentAbsentStamp;
 }): IngestStamp {
   const languages: Record<string, LanguageStamp> = {};
   for (const [lang, identity] of Object.entries(opts.languages)) {
@@ -231,7 +417,7 @@ export function buildIngestStamp(opts: {
       consolidation_version: identity.version_number,
     };
   }
-  return {
+  const stamp: IngestStamp = {
     retrieved_at: opts.now,
     source: 'finlex-opendata',
     doc_type: opts.primary.doc_type,
@@ -241,6 +427,10 @@ export function buildIngestStamp(opts: {
     eli_uri: opts.primary.eli_uri,
     languages,
   };
+  if (opts.lifecycle) stamp.lifecycle = opts.lifecycle;
+  if (opts.statusBasis) stamp.status_basis = opts.statusBasis;
+  if (opts.consolidatedContentAbsent) stamp.consolidated_content_absent = opts.consolidatedContentAbsent;
+  return stamp;
 }
 
 /** Read the stamped consolidation version from an existing seed file's parsed JSON. */
@@ -250,4 +440,59 @@ export function stampedVersionOf(seed: unknown): string | null {
   if (typeof ingest !== 'object' || ingest === null) return null;
   const version = (ingest as Record<string, unknown>).consolidation_version;
   return typeof version === 'string' ? version : null;
+}
+
+/**
+ * Per-language stamped consolidation versions, or null when the seed carries
+ * no stamp. A seed whose Swedish entry is missing was written with Swedish
+ * omitted (not available / version mismatch) and must be re-examined on
+ * refresh — the Finnish version alone does not prove the seed is complete.
+ */
+export function stampedLanguageVersionsOf(seed: unknown): Record<string, string | null> | null {
+  if (typeof seed !== 'object' || seed === null) return null;
+  const ingest = (seed as Record<string, unknown>)._ingest;
+  if (typeof ingest !== 'object' || ingest === null) return null;
+  const languages = (ingest as Record<string, unknown>).languages;
+  if (typeof languages !== 'object' || languages === null) return null;
+  const result: Record<string, string | null> = {};
+  for (const [lang, entry] of Object.entries(languages as Record<string, unknown>)) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const version = (entry as Record<string, unknown>).consolidation_version;
+    result[lang] = typeof version === 'string' ? version : null;
+  }
+  return result;
+}
+
+export interface SeedStampInfo {
+  doc_type: FinlexDocType | null;
+  consolidation_version: string | null;
+  /** Version of the empty consolidated shell, when the seed fell back to the original. */
+  content_absent_version: string | null;
+}
+
+/**
+ * Full stamp identity for freshness classification. Distinguishes
+ * stamped-as-enacted (doc_type 'statute', consolidation_version null — the
+ * legitimate consolidated-404 cohort, freshness PROVEN) from unstamped
+ * (no _ingest at all — freshness unprovable). Collapsing both to "no version"
+ * was the check-updates:241 defect.
+ */
+export function seedStampInfoOf(seed: unknown): SeedStampInfo | null {
+  if (typeof seed !== 'object' || seed === null) return null;
+  const ingest = (seed as Record<string, unknown>)._ingest;
+  if (typeof ingest !== 'object' || ingest === null) return null;
+  const record = ingest as Record<string, unknown>;
+  const docType = record.doc_type;
+  const version = record.consolidation_version;
+  const contentAbsent = record.consolidated_content_absent;
+  let contentAbsentVersion: string | null = null;
+  if (typeof contentAbsent === 'object' && contentAbsent !== null) {
+    const v = (contentAbsent as Record<string, unknown>).version;
+    contentAbsentVersion = typeof v === 'string' ? v : null;
+  }
+  return {
+    doc_type: docType === 'statute' || docType === 'statute-consolidated' ? docType : null,
+    consolidation_version: typeof version === 'string' ? version : null,
+    content_absent_version: contentAbsentVersion,
+  };
 }

--- a/scripts/lib/fs-atomic.ts
+++ b/scripts/lib/fs-atomic.ts
@@ -1,0 +1,29 @@
+/**
+ * Atomic file writes for acquisition outputs (seeds, caches, reports).
+ *
+ * A plain writeFileSync interrupted by SIGKILL/OOM/ENOSPC leaves a truncated
+ * file in place — for seed files that masquerades as "unstamped, self-heal",
+ * and for cached source XML it is a STICKY failure (the corrupt cache is
+ * trusted on every later run). tmp-file + rename makes the swap atomic on
+ * POSIX: readers see either the old complete file or the new complete file.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function writeFileAtomicSync(filePath: string, data: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp-${process.pid}`;
+  try {
+    fs.writeFileSync(tmpPath, data, 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    // Never leave tmp litter behind on failure.
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // tmp file never created / already renamed — nothing to clean.
+    }
+    throw error;
+  }
+}

--- a/scripts/lib/fs-atomic.ts
+++ b/scripts/lib/fs-atomic.ts
@@ -13,6 +13,20 @@ import * as path from 'path';
 
 export function writeFileAtomicSync(filePath: string, data: string): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  // Sweep orphan tmp files from earlier SIGKILLed/OOMed runs: writes are
+  // serialized per target file, so any surviving `<file>.tmp-<pid>` is an
+  // orphan by definition (a different pid never cleans it otherwise).
+  const dir = path.dirname(filePath);
+  const orphanPrefix = `${path.basename(filePath)}.tmp-`;
+  for (const entry of fs.readdirSync(dir)) {
+    if (entry.startsWith(orphanPrefix)) {
+      try {
+        fs.unlinkSync(path.join(dir, entry));
+      } catch {
+        // already gone — fine
+      }
+    }
+  }
   const tmpPath = `${filePath}.tmp-${process.pid}`;
   try {
     fs.writeFileSync(tmpPath, data, 'utf-8');

--- a/sources.yml
+++ b/sources.yml
@@ -19,9 +19,14 @@ sources:
     canonical_identifier: 'Statute number (e.g., 1050/2018)'
     retrieval_method: 'API'
     api_documentation: 'https://finlex.fi/fi/api/'
+    # Version discipline (issue #78): statutes are acquired from the CURRENT
+    # consolidation (akn/fi/act/statute-consolidated/{y}/{n}/fin@latest, ELI
+    # ajantasa) and version-stamped in each seed (`_ingest`). The original
+    # as-enacted expression (act/statute/.../fin@, ELI alkup) is used only on
+    # a definitive consolidated 404. Refresh sweep: `npm run ingest:refresh`.
     update_frequency: 'daily'
-    last_ingested: '2026-02-14'
-    last_verified: '2026-05-09'
+    last_ingested: '2026-06-10'
+    last_verified: '2026-06-10'
     license_or_terms:
       type: 'FI-Statutory-PD'
       url: 'https://finlex.fi/fi/lainsaadanto/1961/404'
@@ -55,4 +60,24 @@ sources:
 data_freshness:
   automated_checks: true
   check_frequency: 'daily'
-  last_verified: '2026-02-15'
+  last_verified: '2026-06-10'
+
+# Fix-Sweep rebuild contract (chassis corpus freshness automation).
+# Schema: Ansvar-Architecture-Documentation/infrastructure/policy/rebuild-contract.schema.json
+# Runbook: Ansvar-Architecture-Documentation/docs/runbooks/fix-sweep.md
+# Supersedes the 2026-06-10 fan-out's runnable:false draft (unpushed commit
+# 55d28cd on feat/2026-06-10-rebuild-contract): the "corrupted seed data" that
+# blocked that declaration was uncommitted chassis-migration WIP in the working
+# tree, not the committed corpus. On this branch the committed seeds build.
+rebuild_contract:
+  schema_version: '1.0'
+  runnable: true
+  ingest_cmd: 'npm run ingest:refresh'
+  build_cmd: 'npm run build:db'
+  build_cwd: '.'
+  premium_build_cmd: 'npm run build:db:paid'
+  output_db: 'data/database.db'
+  schema_kind: 'statute'
+  drift_cmd: 'npm run drift:detect'
+  golden_hashes: 'fixtures/golden-hashes.json'
+  node_version: '22'

--- a/tests/fixtures/finlex/statute-2005-45-fin-original.xml
+++ b/tests/fixtures/finlex/statute-2005-45-fin-original.xml
@@ -1,0 +1,124 @@
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:finlex="http://data.finlex.fi/schema/finlex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <act contains="originalVersion" name="main">
+        <meta>
+            <identification source="#organization_fi.finlex">
+                <FRBRWork>
+                    <FRBRthis value="/akn/fi/act/statute/2005/45/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute/2005/45"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2005/45/alkup"/>
+                    <FRBRdate date="2005-01-28" name="dateIssued"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.parliament"/>
+                    <FRBRcountry value="fi"/>
+                    <FRBRsubtype value="statute"/>
+                    <FRBRnumber value="45"/>
+                    <FRBRprescriptive value="true"/>
+                    <FRBRauthoritative value="true"/>
+                </FRBRWork>
+                <FRBRExpression>
+                    <FRBRthis value="/akn/fi/act/statute/2005/45/fin@/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute/2005/45/fin@"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2005/45/alkup/fin"/>
+                    <FRBRdate date="2005-01-28" name="dateIssued"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.parliament"/>
+                    <FRBRlanguage language="fin"/>
+                </FRBRExpression>
+                <FRBRManifestation>
+                    <FRBRthis value="/akn/fi/act/statute/2005/45/fin@/!main.xml"/>
+                    <FRBRuri value="/akn/fi/act/statute/2005/45/fin@.akn"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2005/45/alkup/fin/xml"/>
+                    <FRBRdate date="2025-02-22" name="dateProduced"/>
+                    <FRBRauthor as="#role_editor" href="#organization_fi.finlex"/>
+                    <FRBRformat value="xml"/>
+                </FRBRManifestation>
+            </identification>
+            <references source="#organization_fi.finlex">
+                <TLCOrganization eId="organization_fi.finlex" href="/akn/ontology/organization/fi.finlex" showAs="Finlex"/>
+                <TLCRole eId="role_author" href="/akn/ontology/role/author" showAs="Tekijä"/>
+                <TLCRole eId="role_editor" href="/akn/ontology/role/editor" showAs="Toimittaja"/>
+                <TLCConcept eId="act" href="/akn/ontology/concept/statute/type-statute.act" showAs="Laki"/>
+                <TLCConcept eId="new-statute" href="/akn/ontology/concept/statute/category-statute.new-statute" showAs="Uusi säädös"/>
+            </references>
+            <proprietary source="#organization_fi.finlex">
+                <finlex:typeStatute refersTo="#act"/>
+                <finlex:categoryStatute refersTo="#new-statute"/>
+                <finlex:documentYear>2005</finlex:documentYear>
+                <finlex:statuteBookOfFinlandReference>
+                    <finlex:year value="2005"/>
+                    <finlex:number value="10"/>
+                    <finlex:date date="2005-02-02"/>
+                </finlex:statuteBookOfFinlandReference>
+            </proprietary>
+        </meta>
+        <preface>
+            <p>
+                <docNumber>45/2005</docNumber>
+                <docTitle>Laki keskinäisestä oikeusavusta rikosasioissa Euroopan unionin jäsenvaltioiden välillä tehtyyn yleissopimukseen liitettävän pöytäkirjan lainsäädännön alaan kuuluvien määräysten voimaansaattamisesta</docTitle>
+            </p>
+        </preface>
+        <preamble>
+            <formula name="enactingClause">
+                <p>Eduskunnan päätöksen mukaisesti säädetään:</p>
+            </formula>
+        </preamble>
+        <body>
+            <hcontainer finlex:outline="Säädöksen teksti" name="statuteProvisionsWrapper">
+                <section eId="sec_1">
+                    <num>1 §</num>
+                    <subsection eId="sec_1__subsec_1">
+                        <content>
+                            <p>Keskinäisestä oikeusavusta rikosasioissa Euroopan unionin jäsenvaltioiden välillä tehtyyn yleissopimukseen liitettävän Luxemburgissa 16 päivänä lokakuuta 2001 tehdyn pöytäkirjan lainsäädännön alaan kuuluvat määräykset ovat lakina voimassa sellaisina kuin Suomi on niihin sitoutunut.</p>
+                        </content>
+                    </subsection>
+                </section>
+                <section eId="sec_2">
+                    <num>2 §</num>
+                    <subsection eId="sec_2__subsec_1">
+                        <content>
+                            <p>Tarkempia säännöksiä tämän lain täytäntöönpanosta voidaan antaa valtioneuvoston asetuksella.</p>
+                        </content>
+                    </subsection>
+                </section>
+                <section eId="sec_3">
+                    <num>3 §</num>
+                    <subsection eId="sec_3__subsec_1">
+                        <content>
+                            <p>Tämän lain voimaantulosta säädetään valtioneuvoston asetuksella.</p>
+                        </content>
+                    </subsection>
+                    <subsection eId="sec_3__subsec_2">
+                        <content>
+                            <p>Valtioneuvoston asetuksella voidaan säätää, että tätä lakia sovelletaan ennen pöytäkirjan kansainvälistä voimaantuloa Suomen ja pöytäkirjan 13 artiklan 5 kohdassa tarkoitetun ilmoituksen antaneen jäsenvaltion välillä.</p>
+                        </content>
+                    </subsection>
+                </section>
+            </hcontainer>
+            <hcontainer finlex:outline="Esityöt ja allekirjoitukset" name="conclusions">
+                <hcontainer finlex:outline="Esityöt" name="preliminaryWork">
+                    <content>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2004/178">HE 178/2004</ref>
+                        </p>
+                        <p>LaVM 13/2004</p>
+                        <p>EV 242/2004</p>
+                        <p>Neuvoston säädös (2001/C326/01); EYVL N:o C 326, 21.11.2001, s. 1</p>
+                    </content>
+                </hcontainer>
+                <hcontainer finlex:outline="Allekirjoitukset" name="signatures">
+                    <content>
+                        <p>Helsingissä 28 päivänä tammikuuta 2005</p>
+                        <p>
+                            <signature>
+                                <role refersTo="">Tasavallan Presidentti </role>
+                                <person refersTo="">TARJA HALONEN</person>
+                            </signature>
+                            <signature>
+                                <role refersTo="">Ministeri </role>
+                                <person refersTo="">Leena Luhtanen</person>
+                            </signature>
+                        </p>
+                    </content>
+                </hcontainer>
+            </hcontainer>
+        </body>
+    </act>
+</akomaNtoso>

--- a/tests/fixtures/finlex/statute-2018-1050-fin-original.xml
+++ b/tests/fixtures/finlex/statute-2018-1050-fin-original.xml
@@ -1,0 +1,931 @@
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:finlex="http://data.finlex.fi/schema/finlex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <act contains="originalVersion" name="main">
+        <meta>
+            <identification source="#organization_fi.finlex">
+                <FRBRWork>
+                    <FRBRthis value="/akn/fi/act/statute/2018/1050/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute/2018/1050"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/alkup"/>
+                    <FRBRdate date="2018-12-05" name="dateIssued"/>
+                    <FRBRdate date="2018-12-10" name="datePublished"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.parliament"/>
+                    <FRBRcountry value="fi"/>
+                    <FRBRsubtype value="statute"/>
+                    <FRBRnumber value="1050"/>
+                    <FRBRprescriptive value="true"/>
+                    <FRBRauthoritative value="true"/>
+                </FRBRWork>
+                <FRBRExpression>
+                    <FRBRthis value="/akn/fi/act/statute/2018/1050/fin@/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute/2018/1050/fin@"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/alkup/fin"/>
+                    <FRBRdate date="2018-12-05" name="dateIssued"/>
+                    <FRBRdate date="2018-12-10" name="datePublished"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.parliament"/>
+                    <FRBRlanguage language="fin"/>
+                </FRBRExpression>
+                <FRBRManifestation>
+                    <FRBRthis value="/akn/fi/act/statute/2018/1050/fin@/!main.xml"/>
+                    <FRBRuri value="/akn/fi/act/statute/2018/1050/fin@.akn"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/alkup/fin/xml"/>
+                    <FRBRdate date="2025-09-05" name="dateProduced"/>
+                    <FRBRdate date="2018-12-10" name="datePublished"/>
+                    <FRBRauthor as="#role_editor" href="#organization_fi.finlex"/>
+                    <FRBRformat value="xml"/>
+                </FRBRManifestation>
+            </identification>
+            <references source="#organization_fi.finlex">
+                <TLCOrganization eId="organization_fi.finlex" href="/akn/ontology/organization/fi.finlex" showAs="Finlex"/>
+                <TLCRole eId="role_author" href="/akn/ontology/role/author" showAs="Tekijä"/>
+                <TLCRole eId="role_editor" href="/akn/ontology/role/editor" showAs="Toimittaja"/>
+                <TLCConcept eId="act" href="/akn/ontology/concept/statute/type-statute.act" showAs="Laki"/>
+                <TLCConcept eId="new-statute" href="/akn/ontology/concept/statute/category-statute.new-statute" showAs="Uusi säädös"/>
+            </references>
+            <proprietary source="#organization_fi.finlex">
+                <finlex:typeStatute refersTo="#act"/>
+                <finlex:categoryStatute refersTo="#new-statute"/>
+                <finlex:documentYear>2018</finlex:documentYear>
+            </proprietary>
+        </meta>
+        <preface>
+            <p>
+                <docNumber>1050/2018</docNumber>
+                <docTitle>Tietosuojalaki</docTitle>
+            </p>
+        </preface>
+        <preamble>
+            <formula name="enactingClause">
+                <p>Eduskunnan päätöksen mukaisesti säädetään:</p>
+            </formula>
+        </preamble>
+        <body>
+            <hcontainer finlex:outline="Säädöksen teksti" name="statuteProvisionsWrapper">
+                <chapter eId="chp_1">
+                    <num>1 luku</num>
+                    <heading>Yleiset säännökset</heading>
+                    <section eId="chp_1__sec_1">
+                        <num>1 §</num>
+                        <heading>Lain tarkoitus</heading>
+                        <subsection eId="chp_1__sec_1__subsec_1">
+                            <content>
+                                <p>
+                                    Tällä lailla täsmennetään ja täydennetään luonnollisten henkilöiden suojelusta henkilötietojen käsittelyssä sekä näiden tietojen vapaasta liikkuvuudesta ja direktiivin 95/46/EY kumoamisesta annettua Euroopan parlamentin ja neuvoston asetusta (EU) 2016/679 (yleinen tietosuoja-asetus), jäljempänä 
+                                    <i>tietosuoja-asetus</i>, ja sen kansallista soveltamista.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_1__sec_2">
+                        <num>2 §</num>
+                        <heading>Soveltamisala</heading>
+                        <subsection eId="chp_1__sec_2__subsec_1">
+                            <content>
+                                <p>Tätä lakia sovelletaan tietosuoja-asetuksen 2 artiklan soveltamisalan mukaisesti. Tätä lakia ja tietosuoja-asetusta sovelletaan lisäksi, lukuun ottamatta asetuksen 56 artiklaa ja VII lukua, sellaiseen henkilötietojen käsittelyyn, jota suoritetaan mainitun 2 artiklan 2 kohdan a ja b alakohdassa tarkoitetun toiminnan yhteydessä, jollei muualla laissa toisin säädetä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_2">
+                            <content>
+                                <p>Tätä lakia ei sovelleta eduskunnan valtiopäivätoimintaan.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_3">
+                            <content>
+                                <p>Tätä lakia ei sovelleta sellaiseen henkilötietojen käsittelyyn, josta säädetään henkilötietojen käsittelystä rikosasioissa ja kansallisen turvallisuuden ylläpitämisen yhteydessä annetussa laissa (1054/2018).</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_1__sec_3">
+                        <num>3 §</num>
+                        <heading>Sovellettava laki</heading>
+                        <subsection eId="chp_1__sec_3__subsec_1">
+                            <content>
+                                <p>Henkilötietojen käsittelyyn, joka tapahtuu Euroopan unionin alueella sijaitsevaan rekisterinpitäjän tai henkilötietojen käsittelijän toimipaikkaan liittyvän toiminnan yhteydessä, sovelletaan Suomen lakia, jos rekisterinpitäjän toimipaikka sijaitsee Suomessa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_3__subsec_2">
+                            <content>
+                                <p>Jos henkilötietojen käsittelyyn sovelletaan vieraan valtion lakia ja sen nojalla poiketaan tietosuoja-asetuksen 89 artiklan 2 kohdan mukaisesti rekisteröidyn suojaksi säädetyistä oikeuksista, jäljempänä 31 §:ssä rekisteröidyn suojaksi säädettyjä suojatoimia on kuitenkin noudatettava lainvalinnasta riippumatta.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_2">
+                    <num>2 luku</num>
+                    <heading>Käsittelyn oikeusperuste eräissä tapauksissa</heading>
+                    <section eId="chp_2__sec_4">
+                        <num>4 §</num>
+                        <heading>Käsittelyn lainmukaisuus</heading>
+                        <subsection eId="chp_2__sec_4__subsec_1">
+                            <intro eId="chp_2__sec_4__subsec_1__intro">
+                                <p>Henkilötietoja saa käsitellä tietosuoja-asetuksen 6 artiklan 1 kohdan e alakohdan mukaisesti, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_1">
+                                <num>1) </num>
+                                <content>
+                                    <p>kysymys on henkilön asemaa, tehtäviä sekä niiden hoitoa julkisyhteisössä, elinkeinoelämässä, järjestötoiminnassa tai muussa vastaavassa toiminnassa kuvaavista tiedoista siltä osin kuin käsittelyn tavoite on yleisen edun mukainen ja käsittely on oikeasuhtaista sillä tavoiteltuun oikeutettuun päämäärään nähden;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_2">
+                                <num>2) </num>
+                                <content>
+                                    <p>käsittely on tarpeen ja oikeasuhtaista viranomaisen toiminnassa yleisen edun mukaisen tehtävän suorittamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_3">
+                                <num>3) </num>
+                                <content>
+                                    <p>käsittely on tarpeen tieteellistä tai historiallista tutkimusta taikka tilastointia varten ja se on oikeasuhtaista sillä tavoiteltuun yleisen edun mukaiseen tavoitteeseen nähden; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_4">
+                                <num>4) </num>
+                                <content>
+                                    <p>henkilötietoja sisältävien tutkimusaineistojen, kulttuuriperintöaineistojen sekä näiden kuvailutietoihin liittyvien henkilötietojen käsittely arkistointitarkoituksessa on tarpeen ja oikeasuhtaista sillä tavoiteltuun yleisen edun mukaiseen tavoitteeseen ja rekisteröidyn oikeuksiin nähden.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_5">
+                        <num>5 §</num>
+                        <heading>Tietoyhteiskunnan palvelujen tarjoamiseen lapselle sovellettava ikäraja</heading>
+                        <subsection eId="chp_2__sec_5__subsec_1">
+                            <content>
+                                <p>Kun henkilötietoja käsitellään tietosuoja-asetuksen 6 artiklan 1 kohdan a alakohdassa tarkoitetun suostumuksen perusteella ja kyseessä on tietosuoja-asetuksen 4 artiklan 25 kohdassa tarkoitettujen tietoyhteiskunnan palvelujen tarjoaminen suoraan lapselle, lapsen henkilötietojen käsittely on lainmukaista, jos lapsi on vähintään 13-vuotias.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_6">
+                        <num>6 §</num>
+                        <heading>Erityisiä henkilötietoryhmiä koskeva käsittely</heading>
+                        <subsection eId="chp_2__sec_6__subsec_1">
+                            <intro eId="chp_2__sec_6__subsec_1__intro">
+                                <p>Tietosuoja-asetuksen 9 artiklan 1 kohtaa ei sovelleta:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_1">
+                                <num>1) </num>
+                                <content>
+                                    <p>vakuutuslaitoksen käsitellessä vakuutustoiminnassa saatuja tietoja vakuutetun ja korvauksenhakijan terveydentilasta, sairaudesta tai vammaisuudesta taikka sellaista häneen kohdistetuista hoitotoimenpiteistä tai niihin verrattavista toimista, jotka ovat tarpeen vakuutuslaitoksen vastuun selvittämiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_2">
+                                <num>2) </num>
+                                <content>
+                                    <p>tietojen käsittelyyn, josta säädetään laissa tai joka johtuu välittömästi rekisterinpitäjälle laissa säädetystä tehtävästä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_3">
+                                <num>3) </num>
+                                <content>
+                                    <p>ammattiliittoon kuulumista koskevaan tiedon käsittelyyn, joka on tarpeen rekisterinpitäjän erityisten oikeuksien ja velvoitteiden noudattamiseksi työoikeuden alalla;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_4">
+                                <num>4) </num>
+                                <content>
+                                    <p>kun terveydenhuollon palveluntarjoaja järjestäessään tai tuottaessaan palveluja käsittelee tässä toiminnassa saamiaan tietoja henkilön terveydentilasta tai vammaisuudesta taikka hänen saamastaan terveydenhuollon ja kuntoutuksen palvelusta taikka muita rekisteröidyn hoidon kannalta välttämättömiä tietoja;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_5">
+                                <num>5) </num>
+                                <content>
+                                    <p>kun sosiaalihuollon palveluntarjoaja järjestäessään tai tuottaessaan palveluja tai myöntäessään etuuksia käsittelee tässä toiminnassa saamiaan tai tuottamiaan tietoja henkilön terveydentilasta tai vammaisuudesta taikka hänen saamastaan terveydenhuollon ja kuntoutuksen palvelusta taikka muita rekisteröidyn palvelun tai etuuden myöntämisen kannalta välttämättömiä tietoja;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_6">
+                                <num>6) </num>
+                                <content>
+                                    <p>terveyttä koskevien ja geneettisten tietojen käsittelyyn antidopingtyössä ja vammaisurheilun yhteydessä siltä osin kuin näiden tietojen käsittely on välttämätöntä antidopingtyön tai vammaisten ja pitkäaikaissairaiden urheilun mahdollistamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_7">
+                                <num>7) </num>
+                                <content>
+                                    <p>tieteellistä tai historiallista tutkimusta taikka tilastointia varten tehtävään tietojen käsittelyyn;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_8">
+                                <num>8) </num>
+                                <content>
+                                    <p>tutkimus- ja kulttuuriperintöaineistojen käsittelyyn yleishyödyllisessä arkistointitarkoituksessa geneettisiä tietoja lukuun ottamatta.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_6__subsec_2">
+                            <intro eId="chp_2__sec_6__subsec_2__intro">
+                                <p>Käsiteltäessä henkilötietoja 1 momentissa tarkoitetussa tilanteessa rekisterinpitäjän ja henkilötietojen käsittelijän on toteutettava asianmukaiset ja erityiset toimenpiteet rekisteröidyn oikeuksien suojaamiseksi. Näitä toimenpiteitä ovat:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_1">
+                                <num>1) </num>
+                                <content>
+                                    <p>toimenpiteet, joilla on jälkeenpäin mahdollista varmistaa ja todentaa kenen toimesta henkilötietoja on tallennettu, muutettu tai siirretty;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_2">
+                                <num>2) </num>
+                                <content>
+                                    <p>toimenpiteet, joilla parannetaan henkilötietoja käsittelevän henkilöstön osaamista;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_3">
+                                <num>3) </num>
+                                <content>
+                                    <p>tietosuojavastaavan nimittäminen;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_4">
+                                <num>4) </num>
+                                <content>
+                                    <p>rekisterinpitäjän ja käsittelijän sisäiset toimenpiteet, joilla estetään pääsy henkilötietoihin;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_5">
+                                <num>5) </num>
+                                <content>
+                                    <p>henkilötietojen pseudonymisointi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_6">
+                                <num>6) </num>
+                                <content>
+                                    <p>henkilötietojen salaaminen;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_7">
+                                <num>7) </num>
+                                <content>
+                                    <p>toimenpiteet, joilla käsittelyjärjestelmien ja henkilötietojen käsittelyyn liittyvien palveluiden jatkuva luottamuksellisuus, eheys, käytettävyys ja vikasietoisuus taataan, mukaan lukien kyky palauttaa nopeasti tietojen saatavuus ja pääsy tietoihin fyysisen tai teknisen vian sattuessa;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_8">
+                                <num>8) </num>
+                                <content>
+                                    <p>menettely, jolla testataan, tutkitaan ja arvioidaan säännöllisesti teknisten ja organisatoristen toimenpiteiden tehokkuutta tietojenkäsittelyn turvallisuuden varmistamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_9">
+                                <num>9) </num>
+                                <content>
+                                    <p>erityiset menettelysäännöt, joilla varmistetaan tietosuoja-asetuksen ja tämän lain noudattaminen siirrettäessä henkilötietoja tai käsiteltäessä henkilötietoja muuhun tarkoitukseen;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_10">
+                                <num>10) </num>
+                                <content>
+                                    <p>tietosuoja-asetuksen 35 artiklan mukainen tietosuojaa koskevan vaikutustenarvioinnin laatiminen;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_11">
+                                <num>11) </num>
+                                <content>
+                                    <p>muut tekniset, menettelylliset ja organisatoriset toimenpiteet.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_7">
+                        <num>7 §</num>
+                        <heading>Rikostuomioihin ja rikkomuksiin liittyvä käsittely</heading>
+                        <subsection eId="chp_2__sec_7__subsec_1">
+                            <intro eId="chp_2__sec_7__subsec_1__intro">
+                                <p>Tietosuoja-asetuksen 10 artiklassa tarkoitettuihin rikostuomioihin ja rikkomuksiin tai niihin liittyviin turvaamistoimiin liittyviä henkilötietoja saa käsitellä, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_7__subsec_1__para_1">
+                                <num>1) </num>
+                                <content>
+                                    <p>käsittely on tarpeen oikeusvaateen selvittämiseksi, laatimiseksi, esittämiseksi, puolustamiseksi tai ratkaisemiseksi; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_7__subsec_1__para_2">
+                                <num>2) </num>
+                                <content>
+                                    <p>tietoja käsitellään 6 §:n 1 momentin 1, 2 tai 7 kohdassa säädetyssä tarkoituksessa.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_7__subsec_2">
+                            <content>
+                                <p>Mitä 6 §:n 2 momentissa säädetään toimenpiteistä rekisteröidyn oikeuksien suojaamiseksi, sovelletaan myös käsiteltäessä tämän pykälän 1 momentissa tarkoitettuja henkilötietoja.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_3">
+                    <num>3 luku</num>
+                    <heading>Valvontaviranomainen</heading>
+                    <section eId="chp_3__sec_8">
+                        <num>8 §</num>
+                        <heading>Tietosuojavaltuutettu</heading>
+                        <subsection eId="chp_3__sec_8__subsec_1">
+                            <content>
+                                <p>Tietosuoja-asetuksessa tarkoitettuna kansallisena valvontaviranomaisena oikeusministeriön yhteydessä on tietosuojavaltuutettu.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_8__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu on toiminnassaan itsenäinen ja riippumaton.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_9">
+                        <num>9 §</num>
+                        <heading>Tietosuojavaltuutetun toimisto</heading>
+                        <subsection eId="chp_3__sec_9__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetulla on toimisto, jossa on vähintään kaksi apulaistietosuojavaltuutettua sekä tarpeellinen määrä tietosuojavaltuutetun tehtäväalaan perehtyneitä esittelijöitä ja muuta henkilöstöä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_9__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu nimittää toimiston virkamiehet ja ottaa palvelukseen toimiston muun henkilöstön.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_9__subsec_3">
+                            <content>
+                                <p>Tietosuojavaltuutettu hyväksyy toimiston työjärjestyksen.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_10">
+                        <num>10 §</num>
+                        <heading>Kelpoisuusvaatimukset ja nimitysperusteet</heading>
+                        <subsection eId="chp_3__sec_10__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun ja apulaistietosuojavaltuutetun kelpoisuusvaatimuksena on muu oikeustieteen ylempi korkeakoulututkinto kuin kansainvälisen ja vertailevan oikeustieteen maisterin tutkinto, hyvä perehtyneisyys henkilötietojen suojaa koskeviin asioihin sekä käytännössä osoitettu johtamistaito. Lisäksi edellytetään kykyä hoitaa kansainvälisiä tehtäviä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_11">
+                        <num>11 §</num>
+                        <heading>Nimittäminen ja toimikausi</heading>
+                        <subsection eId="chp_3__sec_11__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun ja apulaistietosuojavaltuutetun nimittää valtioneuvosto viideksi vuodeksi kerrallaan.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_11__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutetuksi ja apulaistietosuojavaltuutetuksi nimitetty vapautuu hoitamasta muuta virkaa siksi ajaksi, jona hän toimii tietosuojavaltuutettuna tai apulaistietosuojavaltuutettuna.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_12">
+                        <num>12 §</num>
+                        <heading>Asiantuntijalautakunta</heading>
+                        <subsection eId="chp_3__sec_12__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun toimistossa on asiantuntijalautakunta, johon kuuluu puheenjohtaja, varapuheenjohtaja ja kolme muuta jäsentä. Kullakin heistä on henkilökohtainen varajäsen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_2">
+                            <content>
+                                <p>Valtioneuvosto asettaa lautakunnan kolmen vuoden toimikaudeksi.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_3">
+                            <content>
+                                <p>Lautakunnan puheenjohtajan ja varapuheenjohtajan on oltava oikeustieteen muun ylemmän korkeakoulututkinnon kuin kansainvälisen ja vertailevan oikeustieteen maisterin tutkinnon suorittanut henkilö, jolla on hyvä perehtyneisyys henkilötietojen suojaa koskeviin asioihin ja muu tehtävän hoidon edellyttämä pätevyys. Lautakunnan muulta jäseneltä edellytetään perehtyneisyyttä henkilötietojen suojaa koskeviin asioihin ja tehtävän hoidon edellyttämää muuta pätevyyttä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_4">
+                            <content>
+                                <p>Lautakunnan jäseneen sovelletaan rikosoikeudellista virkavastuuta koskevia säännöksiä hänen hoitaessaan tässä laissa tarkoitettuja tehtäviä. Vahingonkorvausvastuusta säädetään vahingonkorvauslaissa (412/1974). Lautakunnan jäsenille ja varajäsenille maksetaan tehtävästään palkkio. Oikeusministeriö vahvistaa palkkioiden määrät.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_13">
+                        <num>13 §</num>
+                        <heading>Selvitys sidonnaisuuksista</heading>
+                        <subsection eId="chp_3__sec_13__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun ja apulaistietosuojavaltuutetun on annettava valtion virkamieslain (750/1994) 8 a §:ssä tarkoitettu selvitys sidonnaisuuksistaan.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_14">
+                        <num>14 §</num>
+                        <heading>Tietosuojavaltuutetun tehtävät ja toimivaltuudet</heading>
+                        <subsection eId="chp_3__sec_14__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun   tehtävistä   ja   toimivaltuuksista   säädetään tietosuoja-asetuksen 55–59 artiklassa. Tietosuojavaltuutetulla on myös muita tässä tai muussa laissa säädettyjä tehtäviä ja toimivaltuuksia.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu ei valvo valtioneuvoston oikeuskanslerin eikä eduskunnan oikeusasiamiehen toimintaa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_3">
+                            <content>
+                                <p>Tietosuojavaltuutettu edustaa Suomea Euroopan tietosuojaneuvostossa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_4">
+                            <content>
+                                <p>Tietosuojavaltuutettu akkreditoi tietosuoja-asetuksen 43 artiklassa tarkoitetun sertifiointielimen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_5">
+                            <content>
+                                <p>Tietosuojavaltuutettu laatii vuosittain tietosuoja-asetuksen 59 artiklassa tarkoitetun toimintakertomuksen, joka toimitetaan eduskunnalle ja valtioneuvostolle. Toimintakertomus on pidettävä yleisesti saatavilla.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_15">
+                        <num>15 §</num>
+                        <heading>Tietosuojavaltuutetun päätöksenteko</heading>
+                        <subsection eId="chp_3__sec_15__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutettu ratkaisee asiat esittelystä, jollei hän yksittäistapauksessa toisin päätä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_16">
+                        <num>16 §</num>
+                        <heading>Apulaistietosuojavaltuutetun tehtävät ja toimivaltuudet</heading>
+                        <subsection eId="chp_3__sec_16__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun ja apulaistietosuojavaltuutetun välisestä tehtävien jaosta määrätään tietosuojavaltuutetun toimiston työjärjestyksessä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_16__subsec_2">
+                            <content>
+                                <p>Apulaistietosuojavaltuutetulla on tehtäviensä hoidossa samat toimivaltuudet kuin tietosuojavaltuutetulla.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_17">
+                        <num>17 §</num>
+                        <heading>Asiantuntijalautakunnan tehtävät ja asioiden käsittely</heading>
+                        <subsection eId="chp_3__sec_17__subsec_1">
+                            <content>
+                                <p>Asiantuntijalautakunnan tehtävänä on tietosuojavaltuutetun pyynnöstä antaa lausuntoja henkilötietojen käsittelyä koskevan lainsäädännön soveltamiseen liittyvistä merkittävistä kysymyksistä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_17__subsec_2">
+                            <content>
+                                <p>Lautakunta voi kuulla ulkopuolisia asiantuntijoita.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_17__subsec_3">
+                            <content>
+                                <p>Lautakunnan sihteerinä toimii tietosuojavaltuutetun toimiston esittelijä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_18">
+                        <num>18 §</num>
+                        <heading>Tietosuojavaltuutetun tiedonsaanti- ja tarkastusoikeus</heading>
+                        <subsection eId="chp_3__sec_18__subsec_1">
+                            <content>
+                                <p>Sen lisäksi, mitä tietosuoja-asetuksen 58 artiklan 1 kohdassa säädetään valvontaviranomaisen tiedonsaanti- ja tarkastusoikeudesta, tietosuojavaltuutetulla on oikeus salassapitosäännösten estämättä saada maksutta tehtäviensä hoidon kannalta tarpeelliset tiedot.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_18__subsec_2">
+                            <content>
+                                <p>Pysyväisluonteiseen asumiseen käytetyssä tilassa tarkastuksen saa toimittaa vain, jos se on välttämätöntä tarkastuksen kohteena olevien seikkojen selvittämiseksi ja kyseessä olevassa tapauksessa on olemassa perusteltu ja yksilöity syy epäillä henkilötietojen käsittelyä koskevia säännöksiä rikotun tai rikottavan tavalla, josta voi olla seuraamuksena hallinnollinen seuraamusmaksu tai rikoslaissa (39/1889) säädetty rangaistus.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_19">
+                        <num>19 §</num>
+                        <heading>Asiantuntijoiden käyttö</heading>
+                        <subsection eId="chp_3__sec_19__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutettu voi kuulla ulkopuolisia asiantuntijoita sekä pyytää näiltä lausuntoja.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_19__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu voi käyttää toimivaltaansa kuuluvan tarkastuksen suorittamisessa apunaan ulkopuolisia asiantuntijoita. Asiantuntijaan sovelletaan rikosoikeudellista virkavastuuta koskevia säännöksiä hänen suorittaessaan tällaisia tehtäviä. Vahingonkorvausvastuusta säädetään vahingonkorvauslaissa.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_20">
+                        <num>20 §</num>
+                        <heading>Virka-apu</heading>
+                        <subsection eId="chp_3__sec_20__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetulla on oikeus tehtäviensä suorittamiseksi saada pyynnöstä poliisilta virka-apua.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_4">
+                    <num>4 luku</num>
+                    <heading>Oikeusturva ja seuraamukset</heading>
+                    <section eId="chp_4__sec_21">
+                        <num>21 §</num>
+                        <heading>Oikeus saattaa asia tietosuojavaltuutetun käsiteltäväksi</heading>
+                        <subsection eId="chp_4__sec_21__subsec_1">
+                            <content>
+                                <p>Rekisteröidyllä on oikeus saattaa asia tietosuojavaltuutetun käsiteltäväksi, jos rekisteröity katsoo, että häntä koskevien henkilötietojen käsittelyssä rikotaan sitä koskevaa lainsäädäntöä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_21__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu voi keskeyttää asian käsittelyn, jos siihen liittyvä asia on vireillä tuomioistuimessa.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_22">
+                        <num>22 §</num>
+                        <heading>Uhkasakko</heading>
+                        <subsection eId="chp_4__sec_22__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutettu voi asettaa tietosuoja-asetuksen 58 artiklan 2 kohdan c–g ja j alakohdassa tarkoitetun päätöksen ja tämän lain 18 §:n 1 momenttiin perustuvan tietojen luovuttamista koskevan määräyksen tehosteeksi uhkasakon. Uhkasakon asettamisesta ja tuomitsemisesta maksettavaksi säädetään uhkasakkolaissa (1113/1990).</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_22__subsec_2">
+                            <content>
+                                <p>Uhkasakkoa ei saa asettaa luonnolliselle henkilölle 1 momentissa tarkoitetun tietojen luovuttamista koskevan määräyksen tehosteeksi silloin, kun henkilöä on aihetta epäillä rikoksesta ja tiedot koskevat rikosepäilyn kohteena olevaa asiaa.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_23">
+                        <num>23 §</num>
+                        <heading>Komission päätökset</heading>
+                        <subsection eId="chp_4__sec_23__subsec_1">
+                            <content>
+                                <p>Jos tietosuojavaltuutettu katsoo sillä vireillä olevassa asiassa tarpeelliseksi selvittää, onko tietosuoja-asetuksen 45 artiklassa tarkoitettu Euroopan komission päätös tietosuojan tason riittävyydestä tietosuoja-asetuksen mukainen, tietosuojavaltuutettu voi hakemuksella saattaa ennakkoratkaisun pyytämistä koskevan asian Helsingin hallinto-oikeuden ratkaistavaksi.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_23__subsec_2">
+                            <content>
+                                <p>Hallinto-oikeuden päätökseen saa hakea muutosta valittamalla vain, jos korkein hallinto-oikeus myöntää valitusluvan.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_24">
+                        <num>24 §</num>
+                        <heading>Hallinnollinen seuraamusmaksu</heading>
+                        <subsection eId="chp_4__sec_24__subsec_1">
+                            <content>
+                                <p>
+                                    Tietosuoja-asetuksen 83 artiklassa säädetyn hallinnollisen sakon (<i>hallinnollinen seuraamusmaksu</i>) määrää tietosuojavaltuutetun ja apulaistietosuojavaltuutettujen yhdessä muodostama seuraamuskollegio. Tietosuojavaltuutettu toimii kollegion puheenjohtajana. Apulaistietosuojavaltuutetun ollessa estynyt voi hänen sijaisenaan seuraamuskollegiossa toimia tietosuojavaltuutetun toimiston työjärjestyksessä määrätty esittelijä. Kollegio on päätösvaltainen kolmijäsenisenä.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_2">
+                            <content>
+                                <p>Kollegion päätös tehdään esittelystä. Päätökseksi tulee se kanta, jota enemmistö on kannattanut. Äänten mennessä tasan päätökseksi tulee se kanta, joka on lievempi sille, johon seuraamus kohdistuu.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_3">
+                            <content>
+                                <p>Seuraamusmaksu voidaan määrätä myös tietosuoja-asetuksen 10 artiklan rikkomisesta noudattaen, mitä tietosuoja-asetuksen 83 artiklan 5 kohdassa ja tässä laissa säädetään.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_4">
+                            <content>
+                                <p>Seuraamusmaksua ei voida määrätä valtion viranomaisille, valtion liikelaitoksille, kunnallisille viranomaisille, itsenäisille julkisoikeudellisille laitoksille, eduskunnan virastoille, tasavallan presidentin kanslialle eikä Suomen evankelis-luterilaiselle kirkolle ja Suomen ortodoksiselle kirkolle eikä niiden seurakunnille, seurakuntayhtymille ja muille elimille.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_5">
+                            <content>
+                                <p>Seuraamusmaksua ei saa määrätä, jos on kulunut yli kymmenen vuotta siitä, kun rikkomus tai laiminlyönti on tapahtunut. Jos rikkomus tai laiminlyönti on ollut luonteeltaan jatkuvaa, kymmenen vuoden määräaika lasketaan siitä, kun rikkomus tai laiminlyönti on päättynyt.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_6">
+                            <content>
+                                <p>Seuraamusmaksun täytäntöönpanosta säädetään sakon täytäntöönpanosta annetussa laissa (672/2002). Seuraamusmaksu vanhenee viiden vuoden kuluttua sen määräämispäivästä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_25">
+                        <num>25 §</num>
+                        <heading>Muutoksenhaku</heading>
+                        <subsection eId="chp_4__sec_25__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun ja apulaistietosuojavaltuutetun päätökseen sekä 24 §:n 1 momentissa säädettyyn päätökseen saa hakea muutosta valittamalla hallinto-oikeuteen siten kuin hallintolainkäyttölaissa (586/1996) säädetään.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_25__subsec_2">
+                            <content>
+                                <p>Hallinto-oikeuden päätökseen saa hakea muutosta valittamalla vain, jos korkein hallinto-oikeus myöntää valitusluvan. Myös tietosuojavaltuutettu saa hakea muutosta hallinto-oikeuden päätökseen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_25__subsec_3">
+                            <content>
+                                <p>Tietosuojavaltuutetun tai apulaistietosuojavaltuutetun päätöksessä voidaan määrätä, että päätöstä on noudatettava muutoksenhausta huolimatta, jollei valitusviranomainen toisin määrää.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_26">
+                        <num>26 §</num>
+                        <heading>Rangaistussäännökset</heading>
+                        <subsection eId="chp_4__sec_26__subsec_1">
+                            <content>
+                                <p>Rangaistus tietosuojarikoksesta säädetään rikoslain 38 luvun 9 §:ssä. Rangaistus viestintäsalaisuuden loukkauksesta ja törkeästä viestintäsalaisuuden loukkauksesta säädetään rikoslain 38 luvun 3 ja 4 §:ssä sekä rangaistus tietomurrosta ja törkeästä tietomurrosta 38 luvun 8 ja 8 a §:ssä. Rangaistus tämän lain 35 §:ssä säädetyn vaitiolovelvollisuuden ja 36 §:ssä säädetyn salassapitovelvollisuuden rikkomisesta tuomitaan rikoslain 38 luvun 1 tai 2 §:n mukaan, jollei teko ole rangaistava rikoslain 40 luvun 5 §:n mukaan tai siitä muualla laissa säädetä ankarampaa rangaistusta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_26__subsec_2">
+                            <content>
+                                <p>Rikoslain 38 luvun 10 §:n 3 momentissa säädetään syyttäjän velvollisuudesta kuulla tietosuojavaltuutettua ennen tämän pykälän 1 momentissa mainittuja rikoksia koskevan syytteen nostamista samoin kuin tuomioistuimen velvollisuudesta varata tällaista asiaa käsitellessään tietosuojavaltuutetulle tilaisuus tulla kuulluksi.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_5">
+                    <num>5 luku</num>
+                    <heading>Tietojenkäsittelyn erityistilanteet</heading>
+                    <section eId="chp_5__sec_27">
+                        <num>27 §</num>
+                        <heading>Henkilötietojen käsittely journalistisen, akateemisen, taiteellisen tai kirjallisen ilmaisun tarkoituksia varten</heading>
+                        <subsection eId="chp_5__sec_27__subsec_1">
+                            <content>
+                                <p>Sananvapauden ja tiedonvälityksen vapauden turvaamiseksi henkilötietojen käsittelyyn ainoastaan journalistisia tarkoituksia varten tai akateemisen, taiteellisen tai kirjallisen ilmaisun tarkoituksia varten ei sovelleta tietosuoja-asetuksen 5 artiklan 1 kohdan c–e alakohtaa, 6  ja  7 artiklaa,  9  ja  10 artiklaa, 11 artiklan 2 kohtaa, 12–22 artiklaa, 30 artiklaa, 34 artiklan 1–3 kohtaa, 35 ja 36 artiklaa, 56 artiklaa, 58 artiklan 2 kohdan f alakohtaa, 60–63 artiklaa ja 65–67 artiklaa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_27__subsec_2">
+                            <content>
+                                <p>Tietosuoja-asetuksen 27 artiklaa ei sovelleta sellaiseen henkilötietojen käsittelyyn, joka liittyy sananvapauden käyttämisestä joukkoviestinnässä annetussa laissa (460/2003) säädettyyn toimintaan. Tietosuoja-asetuksen 44–50 artiklaa ei sovelleta, jos soveltaminen loukkaisi oikeutta sananvapauteen tai tiedonvälityksen vapauteen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_27__subsec_3">
+                            <content>
+                                <p>Sananvapauden ja tiedonvälityksen vapauden turvaamiseksi henkilötietojen käsittelyyn ainoastaan journalistisia tarkoituksia varten tai akateemisen, taiteellisen tai kirjallisen ilmaisun tarkoituksia varten sovelletaan tietosuoja-asetuksen 5 artiklan 1 kohdan a ja b alakohtaa ja 2 kohtaa, 24–26 artiklaa, 31 artiklaa, 39 ja 40 artiklaa, 42 artiklaa, 57 ja 58 artiklaa, 64 artiklaa ja 70 artiklaa ainoastaan soveltuvin osin.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_28">
+                        <num>28 §</num>
+                        <heading>Julkisuusperiaate</heading>
+                        <subsection eId="chp_5__sec_28__subsec_1">
+                            <content>
+                                <p>Oikeuteen saada tieto ja muuhun henkilötietojen luovuttamiseen viranomaisen henkilörekisteristä sovelletaan, mitä viranomaisten toiminnan julkisuudesta säädetään.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_29">
+                        <num>29 §</num>
+                        <heading>Henkilötunnuksen käsittely</heading>
+                        <subsection eId="chp_5__sec_29__subsec_1">
+                            <intro eId="chp_5__sec_29__subsec_1__intro">
+                                <p>Henkilötunnusta saa käsitellä rekisteröidyn suostumuksella tai, jos käsittelystä säädetään laissa. Lisäksi henkilötunnusta saa käsitellä, jos rekisteröidyn yksiselitteinen yksilöiminen on tärkeää:</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_29__subsec_1__para_1">
+                                <num>1) </num>
+                                <content>
+                                    <p>laissa säädetyn tehtävän suorittamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_29__subsec_1__para_2">
+                                <num>2) </num>
+                                <content>
+                                    <p>rekisteröidyn tai rekisterinpitäjän oikeuksien ja velvollisuuksien toteuttamiseksi; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_29__subsec_1__para_3">
+                                <num>3) </num>
+                                <content>
+                                    <p>historiallista tai tieteellistä tutkimusta taikka tilastointia varten.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29__subsec_2">
+                            <content>
+                                <p>Henkilötunnusta saa käsitellä luotonannossa tai saatavan perimisessä, vakuutus-, luottolaitos-, maksupalvelu-, vuokraus- ja lainaustoiminnassa, luottotietotoiminnassa, terveydenhuollossa, sosiaalihuollossa ja muun sosiaaliturvan toteuttamisessa tai virka-, työ- ja muita palvelussuhteita ja niihin liittyviä etuja koskevissa asioissa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29__subsec_3">
+                            <content>
+                                <p>Sen lisäksi, mitä henkilötunnuksen käsittelystä 1 ja 2 momentissa säädetään, henkilötunnuksen saa luovuttaa osoitetietojen päivittämiseksi tai moninkertaisten postilähetysten välttämiseksi suoritettavaa tietojenkäsittelyä varten, jos henkilötunnus jo on luovutuksensaajan käytettävissä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29__subsec_4">
+                            <content>
+                                <p>Henkilötunnusta ei tule merkitä tarpeettomasti henkilörekisterin perusteella tulostettuihin tai laadittuihin asiakirjoihin.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_30">
+                        <num>30 §</num>
+                        <heading>Henkilötietojen käsittely työsuhteen yhteydessä</heading>
+                        <subsection eId="chp_5__sec_30__subsec_1">
+                            <content>
+                                <p>Työntekijää koskevien henkilötietojen käsittelystä, työntekijälle tehtävistä testeistä ja tarkastuksista sekä niitä koskevista vaatimuksista, teknisestä valvonnasta työpaikalla sekä työntekijän sähköpostiviestin hakemisesta ja avaamisesta säädetään yksityisyyden suojasta työelämässä annetussa laissa (759/2004).</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_31">
+                        <num>31 §</num>
+                        <heading>Tieteellisiä ja historiallisia tutkimustarkoituksia sekä tilastollisia tarkoituksia varten tapahtuvaa henkilötietojen käsittelyä koskevat poikkeukset ja suojatoimet</heading>
+                        <subsection eId="chp_5__sec_31__subsec_1">
+                            <intro eId="chp_5__sec_31__subsec_1__intro">
+                                <p>Käsiteltäessä henkilötietoja tieteellistä tai historiallista tutkimustarkoitusta varten voidaan tietosuoja-asetuksen 15, 16, 18 ja 21 artiklassa säädetyistä rekisteröidyn oikeuksista tarvittaessa poiketa edellyttäen, että:</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_31__subsec_1__para_1">
+                                <num>1) </num>
+                                <content>
+                                    <p>käsittely perustuu asianmukaiseen tutkimussuunnitelmaan;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_1__para_2">
+                                <num>2) </num>
+                                <content>
+                                    <p>tutkimuksella on vastuuhenkilö tai siitä vastaava ryhmä; ja</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_1__para_3">
+                                <num>3) </num>
+                                <content>
+                                    <p>henkilötietoja käytetään ja luovutetaan vain historiallista tai tieteellistä tutkimusta taikka muuta yhteensopivaa tarkoitusta varten sekä muutoinkin toimitaan niin, että tiettyä henkilöä koskevat tiedot eivät paljastu ulkopuolisille.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_31__subsec_2">
+                            <intro eId="chp_5__sec_31__subsec_2__intro">
+                                <p>Käsiteltäessä henkilötietoja tilastollisia tarkoituksia varten voidaan tietosuoja-asetuksen 15, 16, 18 ja 21 artiklassa säädetyistä rekisteröidyn oikeuksista tarvittaessa poiketa edellyttäen, että:</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_31__subsec_2__para_1">
+                                <num>1) </num>
+                                <content>
+                                    <p>tilastoa ei voida tuottaa tai sen tarkoituksena olevaa tiedontarvetta toteuttaa ilman henkilötietojen käsittelyä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_2__para_2">
+                                <num>2) </num>
+                                <content>
+                                    <p>kyseisen tilaston tuottamisella on asiallinen yhteys rekisterinpitäjän toimintaan; ja</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_2__para_3">
+                                <num>3) </num>
+                                <content>
+                                    <p>tietoja ei luovuteta tai aseteta saataville siten, että tietty henkilö on niistä tunnistettavissa, ellei tietoja luovuteta julkista tilastoa varten.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_31__subsec_3">
+                            <content>
+                                <p>Käsiteltäessä tietosuoja-asetuksen 9 artiklan 1 kohdassa ja 10 artiklassa tarkoitettuja henkilötietoja 1 tai 2 momentissa säädetyssä tarkoituksessa poikkeaminen tietosuoja-asetuksen 15, 16, 18 ja 21 artiklassa säädetyistä rekisteröidyn oikeuksista edellyttää sen lisäksi, mitä 1 ja 2 momentissa säädetään, että laaditaan tietosuoja-asetuksen 35 artiklan mukainen tietosuojaa koskeva vaikutustenarviointi tai noudatetaan tietosuoja-asetuksen 40 artiklan mukaisia käytännesääntöjä, joissa on otettu asianmukaisesti huomioon edellä tarkoitettu rekisteröidyn oikeuksista poikkeaminen. Vaikutustenarviointi tulee toimittaa kirjallisesti tiedoksi tietosuojavaltuutetulle ennen käsittelyyn ryhtymistä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_32">
+                        <num>32 §</num>
+                        <heading>Yleisen edun mukaisia arkistointitarkoituksia varten tapahtuvaa henkilötietojen käsittelyä koskevat poikkeukset ja suojatoimet</heading>
+                        <subsection eId="chp_5__sec_32__subsec_1">
+                            <content>
+                                <p>Käsiteltäessä henkilötietoja yleisen edun mukaisia arkistointitarkoituksia varten 4 §:n 4 kohdan tai tietosuoja-asetuksen 6 artiklan 1 kohdan c alakohdan nojalla voidaan tietosuoja-asetuksen 15, 16 ja 18–21 artiklassa tarkoitetuista rekisteröidyn oikeuksista poiketa tietosuoja-asetuksen 89 artiklan 3 kohdassa säädetyin edellytyksin.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_33">
+                        <num>33 §</num>
+                        <heading>Rajoitukset rekisterinpitäjän velvollisuuteen toimittaa tietoja rekisteröidylle</heading>
+                        <subsection eId="chp_5__sec_33__subsec_1">
+                            <content>
+                                <p>Tietosuoja-asetuksen 13 ja 14 artiklan mukaisesta velvollisuudesta toimittaa tiedot rekisteröidylle voidaan poiketa, jos se on välttämätöntä valtion turvallisuuden, puolustuksen tai yleisen järjestyksen ja turvallisuuden vuoksi, rikosten ehkäisemiseksi tai selvittämiseksi taikka verotukseen tai julkiseen talouteen liittyvän valvontatehtävän vuoksi.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_33__subsec_2">
+                            <content>
+                                <p>Tietosuoja-asetuksen 14 artiklan 1–4 kohdasta voidaan poiketa myös, jos tiedon toimittaminen aiheuttaa olennaista vahinkoa tai haittaa rekisteröidylle eikä talletettavia tietoja käytetä rekisteröityä koskevaan päätöksentekoon.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_33__subsec_3">
+                            <content>
+                                <p>Jos rekisteröidylle ei toimiteta 1 tai 2 momentin perusteella tietoa, rekisterinpitäjän on toteutettava asianmukaiset toimenpiteet rekisteröidyn oikeuksien suojaamiseksi. Näihin toimenpiteisiin kuuluu tietosuoja-asetuksen 14 artiklan 1 ja 2 kohdassa tarkoitettujen tietojen pitäminen kaikkien saatavilla, ellei tämä vaaranna tietojen toimittamista koskevan rajoituksen tarkoitusta.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_34">
+                        <num>34 §</num>
+                        <heading>Rajoitukset rekisteröidyn oikeuteen tutustua hänestä kerättyihin tietoihin</heading>
+                        <subsection eId="chp_5__sec_34__subsec_1">
+                            <intro eId="chp_5__sec_34__subsec_1__intro">
+                                <p>Rekisteröidyllä ei ole tietosuoja-asetuksen 15 artiklassa tarkoitettua oikeutta tutustua hänestä kerättyihin tietoihin, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_34__subsec_1__para_1">
+                                <num>1) </num>
+                                <content>
+                                    <p>tiedon antaminen saattaisi vahingoittaa kansallista turvallisuutta, puolustusta tai yleistä järjestystä ja turvallisuutta taikka haitata rikosten ehkäisemistä tai selvittämistä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_34__subsec_1__para_2">
+                                <num>2) </num>
+                                <content>
+                                    <p>tiedon antamisesta saattaisi aiheutua vakavaa vaaraa rekisteröidyn terveydelle tai hoidolle taikka rekisteröidyn tai jonkun muun oikeuksille; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_34__subsec_1__para_3">
+                                <num>3) </num>
+                                <content>
+                                    <p>henkilötietoja käytetään valvonta- ja tarkastustehtävissä ja tiedon antamatta jättäminen on välttämätöntä Suomen tai Euroopan unionin tärkeän taloudellisen tai rahoituksellisen edun turvaamiseksi.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_34__subsec_2">
+                            <content>
+                                <p>Jos vain osa rekisteröityä koskevista tiedoista on sellaisia, että ne 1 momentin mukaan jäävät tietosuoja-asetuksen 15 artiklassa tarkoitetun oikeuden ulkopuolelle, rekisteröidyllä on oikeus saada tietää muut häntä koskevat tiedot.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_34__subsec_3">
+                            <content>
+                                <p>Rekisteröidylle on ilmoitettava rajoituksen syyt, ellei tämä vaaranna rajoituksen tarkoitusta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_34__subsec_4">
+                            <content>
+                                <p>Jos rekisteröidyllä ei ole oikeutta tutustua hänestä kerättyihin tietoihin, tietosuoja-asetuksen 15 artiklan 1 kohdassa tarkoitetut tiedot on annettava tietosuojavaltuutetulle rekisteröidyn pyynnöstä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_6">
+                    <num>6 luku</num>
+                    <heading>Erinäiset säännökset</heading>
+                    <section eId="chp_6__sec_35">
+                        <num>35 §</num>
+                        <heading>Vaitiolovelvollisuus</heading>
+                        <subsection eId="chp_6__sec_35__subsec_1">
+                            <content>
+                                <p>Joka henkilötietojen käsittelyyn liittyviä toimenpiteitä suorittaessaan on saanut tietää jotakin toisen henkilön ominaisuuksista, henkilökohtaisista oloista, taloudellisesta asemasta taikka toisen liikesalaisuudesta, ei saa oikeudettomasti ilmaista sivulliselle näin saamiaan tietoja eikä käyttää niitä omaksi tai toisen hyödyksi tai toisen vahingoksi.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_36">
+                        <num>36 §</num>
+                        <heading>Ilmoittajan henkilöllisyyden suojaaminen</heading>
+                        <subsection eId="chp_6__sec_36__subsec_1">
+                            <content>
+                                <p>Kun luonnollinen henkilö on tehnyt tietosuojavaltuutetulle ilmoituksen sen valvontaan kuuluvien säännösten epäillystä rikkomisesta, ilmoittajan henkilöllisyys on pidettävä salassa, jos henkilöllisyyden paljastamisesta voidaan olosuhteiden perusteella arvioida aiheutuvan haittaa ilmoittajalle.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_37">
+                        <num>37 §</num>
+                        <heading>Voimaantulo</heading>
+                        <subsection eId="chp_6__sec_37__subsec_1">
+                            <content>
+                                <p>Tämä laki tulee voimaan 1 päivänä tammikuuta 2019.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_37__subsec_2">
+                            <content>
+                                <p>Tällä lailla kumotaan henkilötietolaki (523/1999) sekä tietosuojalautakunnasta ja tietosuojavaltuutetusta annettu laki (389/1994).</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_38">
+                        <num>38 §</num>
+                        <heading>Siirtymäsäännökset</heading>
+                        <subsection eId="chp_6__sec_38__subsec_1">
+                            <content>
+                                <p>Tietosuojalautakunnan myöntämien lupien voimassaolo päättyy tämän lain tullessa voimaan. Tietosuojalautakunnassa ennen tämän lain voimaantuloa vireille tulleet asiat raukeavat lain voimaan tullessa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_2">
+                            <content>
+                                <p>Tämän lain voimaan tullessa vireillä olevaan tietosuojavaltuutetulle tehtävää ilmoitusta koskevaan asiaan sovelletaan henkilötietolain 36 ja 37 §:n säännöksiä ilmoitusvelvollisuudesta ja ilmoituksen tekemisestä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_3">
+                            <content>
+                                <p>Tämän lain voimaan tullessa vireillä olevassa tarkastusoikeuden toteuttamista ja henkilötietojen korjaamista koskevassa asiassa ei sovelleta sellaisia tietosuoja-asetuksen 12 ja 15–18 artiklan säännöksiä, joissa asetetaan rekisterinpitäjälle laajempia velvollisuuksia kuin tämän lain voimaan tullessa voimassa olleet säännökset edellyttävät, jos mainittujen tietosuoja-asetuksen säännösten soveltaminen olisi rekisterinpitäjän kannalta kohtuutonta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_4">
+                            <content>
+                                <p>Haettaessa muutosta ennen tämän lain voimaantuloa tehtyyn tietosuojalautakunnan ja tietosuojavaltuutetun päätökseen sovelletaan tämän lain voimaan tullessa voimassa olleita säännöksiä. Ylimääräiseen muutoksenhakuun sovelletaan tämän lain voimaan tullessa voimassa olleita säännöksiä kuitenkin vain, jos se on pantu vireille ennen tämän lain voimaantuloa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_5">
+                            <content>
+                                <p>Jos vahinkoa aiheuttanut teko on tehty ennen tämän lain voimaantuloa, velvollisuuteen korvata vahinko sovelletaan tämän lain voimaan tullessa voimassa olleita säännöksiä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+            </hcontainer>
+            <hcontainer finlex:outline="Esityöt ja allekirjoitukset" name="conclusions">
+                <hcontainer finlex:outline="Esityöt" name="preliminaryWork">
+                    <content>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2018/9">HE 9/2018</ref>
+                        </p>
+                        <p>HaVM 13/2018</p>
+                        <p>EV 108/2018</p>
+                        <p>Euroopan parlamentin ja neuvoston asetus (EU) N:o 679/2016 (32016R0679); EUVL L 119, 4.5.2016, s. 1</p>
+                    </content>
+                </hcontainer>
+                <hcontainer finlex:outline="Allekirjoitukset" name="signatures">
+                    <content>
+                        <p>Helsingissä 5 päivänä joulukuuta 2018</p>
+                        <p>
+                            <signature>
+                                <role refersTo="">Tasavallan Presidentti</role>
+                                <person refersTo="">Sauli Niinistö</person>
+                            </signature>
+                            <signature>
+                                <role refersTo="">Oikeusministeri</role>
+                                <person refersTo="">Antti Häkkänen</person>
+                            </signature>
+                        </p>
+                    </content>
+                </hcontainer>
+            </hcontainer>
+        </body>
+    </act>
+</akomaNtoso>

--- a/tests/fixtures/finlex/statute-consolidated-1999-523-fin-latest.xml
+++ b/tests/fixtures/finlex/statute-consolidated-1999-523-fin-latest.xml
@@ -1,0 +1,1604 @@
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:finlex="http://data.finlex.fi/schema/finlex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <act contains="multipleVersions" name="main">
+        <meta>
+            <identification source="#organization_fi.finlex">
+                <FRBRWork>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/1999/523/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/1999/523"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/1999/523/ajantasa"/>
+                    <FRBRdate date="1999-04-22" name="dateIssued"/>
+                    <FRBRdate date="1999-04-29" name="datePublished"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.finlex"/>
+                    <FRBRcountry value="fi"/>
+                    <FRBRsubtype value="statute-consolidated"/>
+                    <FRBRnumber value="523"/>
+                    <FRBRprescriptive value="false"/>
+                    <FRBRauthoritative value="false"/>
+                </FRBRWork>
+                <FRBRExpression>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/1999/523/fin@20150901/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/1999/523/fin@20150901"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/1999/523/ajantasa/2015-08-07/fin"/>
+                    <FRBRdate date="1999-04-22" name="dateIssued"/>
+                    <FRBRdate date="2015-08-07" name="dateConsolidated"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.finlex"/>
+                    <FRBRversionNumber value="20150901"/>
+                    <FRBRlanguage language="fin"/>
+                </FRBRExpression>
+                <FRBRManifestation>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/1999/523/fin@20150901/!main.xml"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/1999/523/fin@20150901.akn"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/1999/523/ajantasa/2015-08-07/fin/xml"/>
+                    <FRBRdate date="2026-05-21" name="dateProduced"/>
+                    <FRBRdate date="1999-04-29" name="datePublished"/>
+                    <FRBRauthor as="#role_editor" href="#organization_fi.finlex"/>
+                    <FRBRformat value="xml"/>
+                </FRBRManifestation>
+            </identification>
+            <classification source="#organization_fi.finlex">
+                <keyword dictionary="/akn/ontology/concept/statute-keyword" showAs="Henkilötieto" value="/akn/ontology/concept/statute-keyword.1565"/>
+                <keyword dictionary="/akn/ontology/concept/statute-keyword" showAs="Tietosuoja" value="/akn/ontology/concept/statute-keyword.3876"/>
+            </classification>
+            <references source="#organization_fi.finlex">
+                <TLCOrganization eId="organization_fi.finlex" href="/akn/ontology/organization/fi.finlex" showAs="Finlex"/>
+                <TLCRole eId="role_author" href="/akn/ontology/role/author" showAs="Tekijä"/>
+                <TLCRole eId="role_editor" href="/akn/ontology/role/editor" showAs="Toimittaja"/>
+                <TLCOrganization eId="fi.ministry-of-justice" href="/akn/ontology/organization/fi.ministry-of-justice" showAs="Oikeusministeriö"/>
+                <TLCConcept eId="act" href="/akn/ontology/concept/statute/type-statute.act" showAs="Laki"/>
+            </references>
+            <proprietary source="#organization_fi.finlex">
+                <finlex:documentYear>1999</finlex:documentYear>
+                <finlex:administrativeBranch refersTo="#fi.ministry-of-justice"/>
+                <finlex:typeStatute refersTo="#act"/>
+                <finlex:isInForce value="false"/>
+                <finlex:inForce>
+                    <finlex:dateEntryIntoForce date="1999-06-01"/>
+                    <finlex:dateInForceEnd date="2018-12-31"/>
+                </finlex:inForce>
+                <finlex:commonName>Tietosuojalaki</finlex:commonName>
+                <finlex:amendedBy>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2010/1049">1049/2010</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2011-01-01">1.1.2011</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 2 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2007/528">528/2007</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2007-11-01">1.11.2007</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>kum. 20 ja 21 §, muutt. 3, 25, 26, 32 ja 36 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2008/512">512/2008</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2008-09-01">1.9.2008</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. L:n 528/2007 voimaantulosäännöstä</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2010/294">294/2010</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2010-05-01">1.5.2010</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 13 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2000/986">986/2000</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2000-12-01">1.12.2000</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 23 §:ää, lis. 22 a §</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2015/901">901/2015</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2016-01-01">1.1.2016</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 45 §</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2011/457">457/2011</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2011-05-17">17.5.2011</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 41 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                </finlex:amendedBy>
+                <finlex:repealedBy>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute-consolidated/2018/1050">1050/2018</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2019-01-01">1.1.2019</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                    </finlex:statuteReference>
+                </finlex:repealedBy>
+                <finlex:repeals>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute-consolidated/1987/471">471/1987</finlex:ref>
+                    </finlex:statuteReference>
+                </finlex:repeals>
+            </proprietary>
+        </meta>
+        <preface>
+            <p>
+                <docNumber>523/1999</docNumber>
+                <docTitle>Henkilötietolaki</docTitle>
+            </p>
+            <block eId="note_1" finlex:outline="huomautus" name="noteAuthorial">
+                Tämä laki on kumottu L:lla 
+                <ref href="/akn/fi/act/statute-consolidated/2018/1050">5.12.2018/1050</ref>, joka on voimassa 1.1.2019 alkaen.
+            </block>
+        </preface>
+        <preamble>
+            <formula name="enactingClause">
+                <p>Eduskunnan päätöksen mukaisesti säädetään:</p>
+            </formula>
+        </preamble>
+        <body>
+            <hcontainer finlex:outline="Säädöksen teksti" name="statuteProvisionsWrapper">
+                <chapter eId="chp_1">
+                    <num>1 luku</num>
+                    <heading eId="chp_1__heading">Yleiset säännökset</heading>
+                    <section eId="chp_1__sec_1">
+                        <num>1 §</num>
+                        <heading eId="chp_1__sec_1__heading">Lain tarkoitus</heading>
+                        <subsection eId="chp_1__sec_1__subsec_1">
+                            <content>
+                                <p>Tämän lain tarkoituksena on toteuttaa yksityiselämän suojaa ja muita yksityisyyden suojaa turvaavia perusoikeuksia henkilötietoja käsiteltäessä sekä edistää hyvän tietojenkäsittelytavan kehittämistä ja noudattamista.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_1__sec_2">
+                        <num>2 §</num>
+                        <heading eId="chp_1__sec_2__heading">Soveltamisala</heading>
+                        <subsection eId="chp_1__sec_2__subsec_1">
+                            <content>
+                                <p>Henkilötietoja käsiteltäessä on noudatettava, mitä tässä laissa säädetään, jollei muualla laissa toisin säädetä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_2">
+                            <content>
+                                <p>Tätä lakia sovelletaan henkilötietojen automaattiseen käsittelyyn. Myös muuhun henkilötietojen käsittelyyn sovelletaan tätä lakia silloin, kun henkilötiedot muodostavat tai niiden on tarkoitus muodostaa henkilörekisteri tai sen osa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_3">
+                            <content>
+                                <p>Tämä laki ei koske henkilötietojen käsittelyä, jonka luonnollinen henkilö suorittaa yksinomaan henkilökohtaisiin tai niihin verrattaviin tavanomaisiin yksityisiin tarkoituksiinsa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_4v20101049">
+                            <content>
+                                <p>
+                                    <i>
+                                        4 momentti on kumottu L:lla 
+                                        <ref href="#entryIntoForce_20101049">3.12.2010/1049</ref>.
+                                    </i>
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_5">
+                            <content>
+                                <p>Henkilötietojen käsittelyä toimituksellisia sekä taiteellisen tai kirjallisen ilmaisun tarkoituksia varten koskevat soveltuvin osin ainoastaan 1–4 ja 32 §, 39 §:n 3 momentti, 40 §:n 1 ja 3 momentti, 42 §, 44 §:n 2 kohta, 45–47 §, 48 §:n 2 momentti sekä 50 ja 51 §, jollei 17 §:stä muuta johdu.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_1__sec_3">
+                        <num>3 §</num>
+                        <heading eId="chp_1__sec_3__heading">Määritelmät</heading>
+                        <subsection eId="chp_1__sec_3__subsec_1">
+                            <intro eId="chp_1__sec_3__subsec_1__intro">
+                                <p>Tässä laissa tarkoitetaan:</p>
+                            </intro>
+                            <paragraph eId="chp_1__sec_3__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>
+                                        <i>henkilötiedolla</i>
+                                         kaikenlaisia luonnollista henkilöä taikka hänen ominaisuuksiaan tai elinolosuhteitaan kuvaavia merkintöjä, jotka voidaan tunnistaa häntä tai hänen perhettään tai hänen kanssaan yhteisessä taloudessa eläviä koskeviksi;
+                                    </p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_1__sec_3__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>
+                                        <i>henkilötietojen käsittelyllä</i>
+                                         henkilötietojen keräämistä, tallettamista, järjestämistä, käyttöä, siirtämistä, luovuttamista, säilyttämistä, muuttamista, yhdistämistä, suojaamista, poistamista, tuhoamista sekä muita henkilötietoihin kohdistuvia toimenpiteitä;
+                                    </p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_1__sec_3__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>
+                                        <i>henkilörekisterillä</i>
+                                         käyttötarkoituksensa vuoksi yhteenkuuluvista merkinnöistä muodostuvaa henkilötietoja sisältävää tietojoukkoa, jota käsitellään osin tai kokonaan automaattisen tietojenkäsittelyn avulla taikka joka on järjestetty kortistoksi, luetteloksi tai muulla näihin verrattavalla tavalla siten, että tiettyä henkilöä koskevat tiedot voidaan löytää helposti ja kohtuuttomitta kustannuksitta;
+                                    </p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_1__sec_3__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>
+                                        <i>rekisterinpitäjällä</i>
+                                         yhtä tai useampaa henkilöä, yhteisöä, laitosta tai säätiötä, jonka käyttöä varten henkilörekisteri perustetaan ja jolla on oikeus määrätä henkilörekisterin käytöstä tai jonka tehtäväksi rekisterinpito on lailla säädetty;
+                                    </p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_1__sec_3__subsec_1__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>
+                                        <i>rekisteröidyllä </i>
+                                        henkilöä, jota henkilötieto koskee;
+                                    </p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_1__sec_3__subsec_1__para_6">
+                                <num>6)</num>
+                                <content>
+                                    <p>
+                                        <i>sivullisella</i>
+                                         muuta henkilöä, yhteisöä, laitosta tai säätiötä kuin rekisteröityä, rekisterinpitäjää, henkilötietojen käsittelijää tai henkilötietoja kahden viimeksi mainitun lukuun käsittelevää;
+                                    </p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_1__sec_3__subsec_1__para_7v20070528" finlex:originalVersion="@20070528" finlex:originalVersionLabel="11.5.2007/528">
+                                <num>7)</num>
+                                <content>
+                                    <p>
+                                        <i>suostumuksella</i>
+                                         kaikenlaista vapaaehtoista, yksilöityä ja tietoista tahdon ilmaisua, jolla rekisteröity hyväksyy henkilötietojensa käsittelyn.
+                                    </p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_1__sec_3__subsec_1__para_8v20070528">
+                                <content>
+                                    <p>
+                                        <i>
+                                            8–9 kohdat on kumottu L:lla 
+                                            <ref href="#entryIntoForce_20070528">11.5.2007/528</ref>.
+                                        </i>
+                                    </p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                    <section eId="chp_1__sec_4">
+                        <num>4 §</num>
+                        <heading eId="chp_1__sec_4__heading">Suomen lain soveltaminen</heading>
+                        <subsection eId="chp_1__sec_4__subsec_1">
+                            <content>
+                                <p>Tätä lakia sovelletaan sellaiseen henkilötietojen käsittelyyn, jossa rekisterinpitäjän toimipaikka on Suomen alueella tai muutoin Suomen oikeudenkäytön piirissä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_4__subsec_2">
+                            <content>
+                                <p>Tätä lakia sovelletaan myös silloin, kun rekisterinpitäjällä ei ole toimipaikkaa Euroopan unionin jäsenvaltioiden alueella, mutta rekisterinpitäjä käyttää henkilötietojen käsittelyssä Suomessa sijaitsevia laitteita muuhunkin tarkoitukseen kuin vain tietojen siirtoon tämän alueen kautta. Rekisterinpitäjän on tällöin nimettävä Suomessa oleva edustaja.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_2">
+                    <num>2 luku</num>
+                    <heading eId="chp_2__heading">Henkilötietojen käsittelyä koskevat yleiset periaatteet</heading>
+                    <section eId="chp_2__sec_5">
+                        <num>5 §</num>
+                        <heading eId="chp_2__sec_5__heading">Huolellisuusvelvoite</heading>
+                        <subsection eId="chp_2__sec_5__subsec_1">
+                            <content>
+                                <p>Rekisterinpitäjän tulee käsitellä henkilötietoja laillisesti, noudattaa huolellisuutta ja hyvää tietojenkäsittelytapaa sekä toimia muutoinkin niin, ettei rekisteröidyn yksityiselämän suojaa ja muita yksityisyyden suojan turvaavia perusoikeuksia rajoiteta ilman laissa säädettyä perustetta. Sama velvollisuus on sillä, joka itsenäisenä elinkeinon- tai toiminnanharjoittajana toimii rekisterinpitäjän lukuun.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_6">
+                        <num>6 §</num>
+                        <heading eId="chp_2__sec_6__heading">Henkilötietojen käsittelyn suunnittelu</heading>
+                        <subsection eId="chp_2__sec_6__subsec_1">
+                            <content>
+                                <p>Henkilötietojen käsittelyn tulee olla asiallisesti perusteltua rekisterinpitäjän toiminnan kannalta. Henkilötietojen käsittelyn tarkoitukset sekä se, mistä henkilötiedot säännönmukaisesti hankitaan ja mihin niitä säännönmukaisesti luovutetaan, on määriteltävä ennen henkilötietojen keräämistä tai muodostamista henkilörekisteriksi. Henkilötietojen käsittelyn tarkoitus tulee määritellä siten, että siitä ilmenee, minkälaisten rekisterinpitäjän tehtävien hoitamiseksi henkilötietoja käsitellään.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_7">
+                        <num>7 §</num>
+                        <heading eId="chp_2__sec_7__heading">Käyttötarkoitussidonnaisuus</heading>
+                        <subsection eId="chp_2__sec_7__subsec_1">
+                            <content>
+                                <p>Henkilötietoja saa käyttää tai muutoin käsitellä vain tavalla, joka ei ole yhteensopimaton 6 §:ssä tarkoitettujen käsittelyn tarkoitusten kanssa. Myöhempää henkilötietojen käsittelyä historiallista tutkimusta taikka tieteellistä tai tilastotarkoitusta varten ei pidetä yhteensopimattomana alkuperäisten käsittelyn tarkoitusten kanssa.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_8">
+                        <num>8 §</num>
+                        <heading eId="chp_2__sec_8__heading">Käsittelyn yleiset edellytykset</heading>
+                        <subsection eId="chp_2__sec_8__subsec_1">
+                            <intro eId="chp_2__sec_8__subsec_1__intro">
+                                <p>Henkilötietoja saa käsitellä ainoastaan:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_8__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>rekisteröidyn yksiselitteisesti antamalla suostumuksella;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_8__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>rekisteröidyn toimeksiannosta tai sellaisen sopimuksen täytäntöönpanemiseksi, jossa rekisteröity on osallisena, taikka sopimusta edeltävien toimenpiteiden toteuttamiseksi rekisteröidyn pyynnöstä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_8__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>jos käsittely yksittäistapauksessa on tarpeen rekisteröidyn elintärkeän edun suojaamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_8__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>jos käsittelystä säädetään laissa tai jos käsittely johtuu rekisterinpitäjälle laissa säädetystä tai sen nojalla määrätystä tehtävästä tai velvoitteesta;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_8__subsec_1__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>
+                                        jos rekisteröidyllä on asiakas- tai palvelussuhteen, jäsenyyden tai muun niihin verrattavan suhteen vuoksi asiallinen yhteys rekisterinpitäjän toimintaan (<i>yhteysvaatimus</i>);
+                                    </p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_8__subsec_1__para_6">
+                                <num>6)</num>
+                                <content>
+                                    <p>jos kysymys on konsernin tai muun taloudellisen yhteenliittymän asiakkaita tai työntekijöitä koskevista tiedoista ja näitä tietoja käsitellään kyseisen yhteenliittymän sisällä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_8__subsec_1__para_7">
+                                <num>7)</num>
+                                <content>
+                                    <p>jos käsittely on tarpeen rekisterinpitäjän toimeksiannosta tapahtuvaa maksupalvelua, tietojenkäsittelyä tai muita niihin verrattavia tehtäviä varten;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_8__subsec_1__para_8">
+                                <num>8)</num>
+                                <content>
+                                    <p>jos kysymys on henkilön asemaa, tehtäviä ja niiden hoitoa julkisyhteisössä tai elinkeinoelämässä kuvaavista yleisesti saatavilla olevista tiedoista ja näitä tietoja käsitellään rekisterinpitäjän tai tiedot saavan sivullisen oikeuksien ja etujen turvaamiseksi; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_8__subsec_1__para_9">
+                                <num>9)</num>
+                                <content>
+                                    <p>jos tietosuojalautakunta on antanut käsittelyyn 43 §:n 1 momentissa tarkoitetun luvan.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_8__subsec_2">
+                            <content>
+                                <p>Henkilötietojen luovuttaminen voi tapahtua 1 momentin 5 kohdan nojalla vain, jos henkilötiedon luovuttaminen kuuluu tavanomaisena osana kysymyksessä olevan toiminnan harjoittamiseen edellyttäen, että tarkoitus, johon tiedot luovutetaan, ei ole yhteensopimaton henkilötietojen käsittelyn tarkoituksen kanssa ja että rekisteröidyn voidaan olettaa tietävän henkilötietojen tällaisesta luovuttamisesta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_2__sec_8__subsec_3">
+                            <content>
+                                <p>Arkaluonteisten henkilötietojen ja henkilötunnuksen käsittelystä säädetään 3 luvussa. Henkilötietojen käsittelystä erityisiä tarkoituksia varten säädetään 4 luvussa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_2__sec_8__subsec_4">
+                            <content>
+                                <p>Oikeudesta saada tieto ja muusta henkilötietojen luovuttamisesta viranomaisen henkilörekisteristä on voimassa, mitä viranomaisten asiakirjojen julkisuudesta säädetään.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_9">
+                        <num>9 §</num>
+                        <heading eId="chp_2__sec_9__heading">Tietojen laatua koskevat periaatteet</heading>
+                        <subsection eId="chp_2__sec_9__subsec_1">
+                            <content>
+                                <p>
+                                    Käsiteltävien henkilötietojen tulee olla määritellyn henkilötietojen käsittelyn tarkoituksen kannalta tarpeellisia (<i>tarpeellisuusvaatimus).</i>
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_2__sec_9__subsec_2">
+                            <content>
+                                <p>
+                                    Rekisterinpitäjän on huolehdittava siitä, ettei virheellisiä, epätäydellisiä tai vanhentuneita henkilötietoja käsitellä (<i>virheettömyysvaatimus</i>). Rekisterinpitäjän velvollisuutta arvioitaessa on otettava huomioon henkilötietojen käsittelyn tarkoitus sekä käsittelyn merkitys rekisteröidyn yksityisyyden suojalle.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_10">
+                        <num>10 §</num>
+                        <heading eId="chp_2__sec_10__heading">Rekisteriseloste</heading>
+                        <subsection eId="chp_2__sec_10__subsec_1">
+                            <intro eId="chp_2__sec_10__subsec_1__intro">
+                                <p>Rekisterinpitäjän on laadittava henkilörekisteristä rekisteriseloste, josta ilmenee:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_10__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>rekisterinpitäjän ja tarvittaessa tämän edustajan nimi ja yhteystiedot;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_10__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>henkilötietojen käsittelyn tarkoitus;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_10__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>kuvaus rekisteröityjen ryhmästä tai ryhmistä ja näihin liittyvistä tiedoista tai tietoryhmistä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_10__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>mihin tietoja säännönmukaisesti luovutetaan ja siirretäänkö tietoja Euroopan unionin tai Euroopan talousalueen ulkopuolelle; sekä</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_10__subsec_1__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>kuvaus rekisterin suojauksen periaatteista.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_10__subsec_2">
+                            <content>
+                                <p>Rekisterinpitäjän on pidettävä rekisteriseloste jokaisen saatavilla. Tästä velvollisuudesta voidaan poiketa, jos se on välttämätöntä valtion turvallisuuden, puolustuksen tai yleisen järjestyksen ja turvallisuuden vuoksi, rikosten ehkäisemiseksi tai selvittämiseksi taikka verotukseen tai julkiseen talouteen liittyvän valvontatehtävän vuoksi.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_3">
+                    <num>3 luku</num>
+                    <heading eId="chp_3__heading">Arkaluonteiset tiedot ja henkilötunnus</heading>
+                    <section eId="chp_3__sec_11">
+                        <num>11 §</num>
+                        <heading eId="chp_3__sec_11__heading">Arkaluonteisten tietojen käsittelykielto</heading>
+                        <subsection eId="chp_3__sec_11__subsec_1">
+                            <intro eId="chp_3__sec_11__subsec_1__intro">
+                                <p>Arkaluonteisten henkilötietojen käsittely on kielletty. Arkaluonteisina tietoina pidetään henkilötietoja, jotka kuvaavat tai on tarkoitettu kuvaamaan:</p>
+                            </intro>
+                            <paragraph eId="chp_3__sec_11__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>rotua tai etnistä alkuperää;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_11__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>henkilön yhteiskunnallista, poliittista tai uskonnollista vakaumusta tai ammattiliittoon kuulumista;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_11__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>rikollista tekoa, rangaistusta tai muuta rikoksen seuraamusta;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_11__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>henkilön terveydentilaa, sairautta tai vammaisuutta taikka häneen kohdistettuja hoitotoimenpiteitä tai niihin verrattavia toimia;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_11__subsec_1__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>henkilön seksuaalista suuntautumista tai käyttäytymistä; taikka</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_11__subsec_1__para_6">
+                                <num>6)</num>
+                                <content>
+                                    <p>henkilön sosiaalihuollon tarvetta tai hänen saamiaan sosiaalihuollon palveluja, tukitoimia ja muita sosiaalihuollon etuuksia.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_12">
+                        <num>12 §</num>
+                        <heading eId="chp_3__sec_12__heading">Poikkeukset arkaluonteisten tietojen käsittelykiellosta</heading>
+                        <subsection eId="chp_3__sec_12__subsec_1">
+                            <intro eId="chp_3__sec_12__subsec_1__intro">
+                                <p>Mitä 11 §:ssä säädetään, ei estä:</p>
+                            </intro>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>tietojen käsittelyä, johon rekisteröity on antanut nimenomaisen suostumuksensa;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>sellaisen henkilön yhteiskunnallista, poliittista tai uskonnollista vakaumusta tai ammattiliittoon kuulumista koskevan tiedon käsittelyä, jonka rekisteröity on itse saattanut julkiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>tietojen käsittelyä, joka on tarpeen rekisteröidyn tai jonkun toisen henkilön elintärkeän edun suojaamiseksi, jos rekisteröity on estynyt antamasta suostumustaan;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>tietojen käsittelyä, joka on tarpeen oikeusvaateen laatimiseksi, esittämiseksi, puolustamiseksi tai ratkaisemiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>tietojen käsittelyä, josta säädetään laissa tai joka johtuu välittömästi rekisterinpitäjälle laissa säädetystä tehtävästä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_6">
+                                <num>6)</num>
+                                <content>
+                                    <p>tietojen käsittelyä historiallista tai tieteellistä tutkimusta taikka tilastointia varten;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_7">
+                                <num>7)</num>
+                                <content>
+                                    <p>uskonnollista, poliittista tai yhteiskunnallista vakaumusta koskevien tietojen käsittelyä tällaista vakaumusta edustavien yhdistysten ja muiden yhteisöjen toiminnassa, jos tiedot koskevat näiden yhdistysten tai yhteisöjen jäseniä taikka henkilöitä, joilla on niihin säännölliset, yhdistysten ja yhteisöjen tarkoituksiin liittyvät yhteydet, eikä tietoja luovuteta sivullisille ilman rekisteröidyn suostumusta;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_8">
+                                <num>8)</num>
+                                <content>
+                                    <p>ammattiliittoon kuulumista koskevien tietojen käsittelyä ammattiyhdistysten ja niiden muodostaman liiton toiminnassa, jos tiedot koskevat näiden järjestöjen jäseniä taikka henkilöitä, joilla on järjestöihin säännölliset, järjestöjen tarkoituksiin liittyvät yhteydet, eikä tietoja luovuteta sivullisille ilman rekisteröidyn suostumusta;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_9">
+                                <num>9)</num>
+                                <content>
+                                    <p>ammattiliittoon kuulumista koskevan tiedon käsittelyä, joka on tarpeen rekisterinpitäjän erityisten oikeuksien ja velvoitteiden noudattamiseksi työoikeuden alalla;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_10">
+                                <num>10)</num>
+                                <content>
+                                    <p>terveydenhuollon toimintayksikköä tai terveydenhuollon ammattihenkilöä käsittelemästä näiden tässä toiminnassa saamia tietoja rekisteröidyn terveydentilasta, sairaudesta tai vammaisuudesta tai häneen kohdistetuista hoitotoimenpiteistä taikka muita rekisteröidyn hoidon kannalta välttämättömiä tietoja;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_11">
+                                <num>11)</num>
+                                <content>
+                                    <p>vakuutuslaitosta käsittelemästä vakuutustoiminnassa saatuja tietoja vakuutetun ja korvauksenhakijan terveydentilasta, sairaudesta tai vammaisuudesta taikka häneen kohdistetuista hoitotoimenpiteistä tai niihin verrattavista toimista taikka sellaisia tietoja vakuutetun, korvauksenhakijan tai vahingon aiheuttajan rikollisesta teosta, rangaistuksesta tai muusta rikoksen seuraamuksesta, jotka ovat tarpeen vakuutuslaitoksen vastuun selvittämiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_12">
+                                <num>12)</num>
+                                <content>
+                                    <p>sosiaalihuollon viranomaista tai muuta sosiaalihuollon etuuksia myöntävää viranomaista, laitosta tai yksityisten sosiaalipalvelujen tuottajaa käsittelemästä kyseisen viranomaisen, laitoksen tai palvelujen tuottajan toiminnassaan saamia tietoja rekisteröidyn sosiaalihuollon tarpeesta tai hänen saamistaan sosiaalihuollon palveluista, tukitoimista tai hänelle myönnetyistä muista sosiaalihuollon etuuksista taikka muita rekisteröidyn huollon kannalta välttämättömiä tietoja; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_12__subsec_1__para_13">
+                                <num>13)</num>
+                                <content>
+                                    <p>tietojen käsittelyä, johon tietosuojalautakunta on antanut 43 §:n 2 momentissa tarkoitetun luvan.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_2">
+                            <content>
+                                <p>Arkaluonteiset tiedot on poistettava rekisteristä välittömästi sen jälkeen, kun käsittelylle ei ole 1 momentissa mainittua perustetta. Perustetta ja käsittelyn tarvetta on arvioitava vähintään viiden vuoden välein, jollei laista tai 1 momentin 13 kohdassa tarkoitetusta tietosuojalautakunnan luvasta muuta johdu.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_13">
+                        <num>13 §</num>
+                        <heading eId="chp_3__sec_13__heading">Henkilötunnuksen käsittely</heading>
+                        <subsection eId="chp_3__sec_13__subsec_1">
+                            <intro eId="chp_3__sec_13__subsec_1__intro">
+                                <p>Henkilötunnusta saa käsitellä rekisteröidyn yksiselitteisesti antamalla suostumuksella tai, jos käsittelystä säädetään laissa. Lisäksi henkilötunnusta saa käsitellä, jos rekisteröidyn yksiselitteinen yksilöiminen on tärkeää:</p>
+                            </intro>
+                            <paragraph eId="chp_3__sec_13__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>laissa säädetyn tehtävän suorittamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_13__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>rekisteröidyn tai rekisterinpitäjän oikeuksien ja velvollisuuksien toteuttamiseksi; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_3__sec_13__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>historiallista tai tieteellistä tutkimusta taikka tilastointia varten.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_3__sec_13__subsec_2v20100294" finlex:originalVersion="@20100294" finlex:originalVersionLabel="30.4.2010/294">
+                            <content>
+                                <p>Henkilötunnusta saa käsitellä luotonannossa tai saatavan perimisessä, vakuutus-, luottolaitos-, maksupalvelu-, vuokraus- ja lainaustoiminnassa, luottotietotoiminnassa, terveydenhuollossa, sosiaalihuollossa ja muun sosiaaliturvan toteuttamisessa tai virka-, työ- ja muita palvelussuhteita ja niihin liittyviä etuja koskevissa asioissa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_13__subsec_3">
+                            <content>
+                                <p>Sen lisäksi, mitä henkilötunnuksen käsittelystä 1 ja 2 momentissa säädetään, henkilötunnuksen saa luovuttaa osoitetietojen päivittämiseksi tai moninkertaisten postilähetysten välttämiseksi suoritettavaa tietojenkäsittelyä varten, jos henkilötunnus jo on luovutuksensaajan käytettävissä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_13__subsec_4">
+                            <content>
+                                <p>Rekisterinpitäjän on huolehdittava siitä, että henkilötunnusta ei merkitä tarpeettomasti henkilörekisterin perusteella tulostettuihin tai laadittuihin asiakirjoihin.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_4">
+                    <num>4 luku</num>
+                    <heading eId="chp_4__heading">Henkilötietojen käsittely erityisiä tarkoituksia varten</heading>
+                    <section eId="chp_4__sec_14">
+                        <num>14 §</num>
+                        <heading eId="chp_4__sec_14__heading">Tutkimus</heading>
+                        <subsection eId="chp_4__sec_14__subsec_1">
+                            <intro eId="chp_4__sec_14__subsec_1__intro">
+                                <p>Historiallista tai tieteellistä tutkimusta varten saa henkilötietoja käsitellä muilla kuin 8 §:n 1 momentissa säädetyillä perusteilla, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_4__sec_14__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>tutkimusta ei voi suorittaa ilman henkilön yksilöintiä koskevia tietoja ja jos rekisteröityjen suostumusta ei tietojen suuren määrän, tietojen iän tai muun sellaisen syyn vuoksi ole mahdollista hankkia;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_4__sec_14__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>henkilörekisterin käyttö perustuu asianmukaiseen tutkimussuunnitelmaan ja tutkimuksella on vastuullinen johtaja tai siitä vastaava ryhmä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_4__sec_14__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>henkilörekisteriä käytetään ja siitä luovutetaan henkilötietoja vain historiallista tai tieteellistä tutkimusta varten sekä muutoinkin toimitaan niin, että tiettyä henkilöä koskevat tiedot eivät paljastu ulkopuolisille; sekä</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_4__sec_14__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>henkilörekisteri hävitetään tai siirretään arkistoitavaksi tai sen tiedot muutetaan sellaiseen muotoon, ettei tiedon kohde ole niistä tunnistettavissa, kun henkilötiedot eivät enää ole tarpeen tutkimuksen suorittamiseksi tai sen tulosten asianmukaisuuden varmistamiseksi.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_4__sec_14__subsec_2">
+                            <content>
+                                <p>Mitä 1 momentin 3 kohdassa säädetään, ei sovelleta, jos siinä tarkoitettu menettely henkilörekisteriin talletettujen tietojen ikä ja laatu huomioon ottaen on rekisteröityjen yksityisyyden suojan vuoksi ilmeisen tarpeetonta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_14__subsec_3">
+                            <content>
+                                <p>Mitä 1 momentissa säädetään, sovelletaan täydentävästi silloin, kun henkilötietojen käsittely perustuu 8 §:n 1 momenttiin.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_15">
+                        <num>15 §</num>
+                        <heading eId="chp_4__sec_15__heading">Tilasto</heading>
+                        <subsection eId="chp_4__sec_15__subsec_1">
+                            <intro eId="chp_4__sec_15__subsec_1__intro">
+                                <p>Tilastotarkoituksia varten saa henkilötietoja käsitellä muilla kuin 8 §:n 1 momentissa säädetyillä perusteilla, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_4__sec_15__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>tilastoa ei voida tuottaa tai sen tarkoituksena olevaa tiedontarvetta toteuttaa ilman henkilötietojen käsittelyä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_4__sec_15__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>tilaston tuottaminen kuuluu rekisterinpitäjän toimialaan; sekä</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_4__sec_15__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>tilastorekisteriä käytetään vain tilastollisiin tarkoituksiin eikä siitä luovuteta tietoja siten, että tietty henkilö on niistä tunnistettavissa, ellei tietoja luovuteta julkista tilastoa varten.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_16">
+                        <num>16 §</num>
+                        <heading eId="chp_4__sec_16__heading">Viranomaisen suunnittelu- ja selvitystehtävät</heading>
+                        <subsection eId="chp_4__sec_16__subsec_1">
+                            <content>
+                                <p>Suunnittelua ja selvitystä varten viranomainen voi muilla kuin 8 §:n 1 momentissa säädetyillä perusteilla kerätä ja tallettaa henkilötietoja viranomaisen henkilörekisteriin noudattaen soveltuvin osin, mitä 14 §:ssä säädetään.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_17">
+                        <num>17 §</num>
+                        <heading eId="chp_4__sec_17__heading">Henkilömatrikkeli</heading>
+                        <subsection eId="chp_4__sec_17__subsec_1">
+                            <content>
+                                <p>Henkilömatrikkelia varten pidettävään henkilörekisteriin saa muilla kuin 8 §:n 1 momentissa säädetyillä perusteilla kerätä ja tallettaa rekisteröidystä ja tämän aviopuolisosta sekä rekisteröidyn lapsista ja vanhemmista rekisterin tarkoituksen kannalta tarpeelliset yksilöintitiedot, tiedon henkilömatrikkelin perusteena olevasta rekisteröityjä yhdistävästä tekijästä ja tähän liittyvät tiedot sekä yhteystiedot yhteydenottoa varten, jollei rekisteröity ole kieltänyt itseään koskevien tietojen keräämistä ja tallettamista.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_17__subsec_2">
+                            <content>
+                                <p>Henkilömatrikkelilla tarkoitetaan julkaisua, jossa rekisteröityjä yhdistävänä tekijänä on tietty ammatti tai koulutus, työ- tai muun yhteisön jäsenyys taikka asema tai saavutukset kulttuurin, urheilun, talouselämän tai muulla yhteiskuntaelämän alalla tai muu näihin rinnastettava seikka.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_17__subsec_3">
+                            <content>
+                                <p>Edellä 1 momentissa tarkoitettua henkilömatrikkelirekisteriä varten saa henkilörekisteristä luovuttaa ne tiedot, jotka rekisterinpitäjällä on 1 momentin mukaan oikeus kerätä ja tallettaa tällaiseen rekisteriin, jollei rekisteröity ole kieltänyt tietojen luovuttamista.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_18">
+                        <num>18 §</num>
+                        <heading eId="chp_4__sec_18__heading">Sukututkimus</heading>
+                        <subsection eId="chp_4__sec_18__subsec_1">
+                            <content>
+                                <p>Sukututkimusta varten pidettävään henkilörekisteriin saa muilla kuin 8 §:n 1 momentissa säädetyillä perusteilla kerätä ja tallettaa sukuun kuuluvasta henkilöstä ja tämän aviopuolisosta rekisterin tarkoituksen kannalta tarpeelliset yksilöintitiedot samoin kuin muut sukututkimuksen kannalta tarpeelliset henkilötiedot sekä yhteystiedot yhteydenottoa varten, jollei rekisteröity ole kieltänyt itseään koskevien tietojen keräämistä ja tallettamista.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_18__subsec_2">
+                            <content>
+                                <p>Edellä 1 momentissa tarkoitettua sukututkimusrekisteriä varten saa henkilörekisteristä luovuttaa ne tiedot, jotka rekisterinpitäjällä on 1 momentin mukaan oikeus kerätä ja tallettaa tällaiseen rekisteriin, jollei rekisteröity ole kieltänyt tietojen luovuttamista.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_19">
+                        <num>19 §</num>
+                        <heading eId="chp_4__sec_19__heading">Suoramarkkinointi ja muut osoitteelliset lähetykset</heading>
+                        <subsection eId="chp_4__sec_19__subsec_1">
+                            <intro eId="chp_4__sec_19__subsec_1__intro">
+                                <p>Suoramainontaan, etämyyntiin tai muuhun suoramarkkinointiin, mielipide- tai markkinatutkimukseen taikka muihin näihin rinnastettaviin osoitteellisiin lähetyksiin käytettävään henkilörekisteriin saa muilla kuin 8 §:n 1 momentissa säädetyillä perusteilla kerätä ja tallettaa henkilötietoja, jollei rekisteröity ole kieltänyt henkilötietojen tällaista keräämistä ja tallettamista, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_4__sec_19__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>henkilörekisteriä käytetään ennakolta yksilöityyn ja kestoltaan lyhytaikaiseen markkinointitoimeen tai muuhun tässä momentissa tarkoitettuun toimeen eikä se tietosisältönsä vuoksi vaaranna rekisteröidyn yksityisyyden suojaa;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_4__sec_19__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>henkilörekisteri sisältää tiedot vain rekisteröidyn nimestä, arvosta tai ammatista, iästä, sukupuolesta ja äidinkielestä, yhden häneen liitettävän tunnistetiedon sekä yhteystiedot yhteydenottoa varten; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_4__sec_19__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>henkilörekisteri sisältää tietoja, jotka koskevat rekisteröidyn tehtäviä ja asemaa elinkeinoelämässä tai julkisessa tehtävässä ja sitä käytetään hänen työtehtäviinsä liittyvän informaation lähettämiseen.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_4__sec_19__subsec_2">
+                            <content>
+                                <p>Edellä 1 momentissa mainittua tarkoitusta varten saa henkilörekisteristä luovuttaa tai luovutuksessa otantaperusteena käyttää 1 momentin 2 kohdassa tarkoitettuja tietoja, jollei rekisteröity ole kieltänyt tiedon luovuttamista ja jos on ilmeistä, että rekisteröity tietää tietojen tällaisesta luovuttamisesta.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_20v20070528">
+                        <num>20 §</num>
+                        <content>
+                            <p>
+                                <i>
+                                    20 § on kumottu L:lla 
+                                    <ref href="#entryIntoForce_20070528">11.5.2007/528</ref>.
+                                </i>
+                            </p>
+                        </content>
+                    </section>
+                    <section eId="chp_4__sec_21v20070528">
+                        <num>21 §</num>
+                        <content>
+                            <p>
+                                <i>
+                                    21 § on kumottu L:lla 
+                                    <ref href="#entryIntoForce_20070528">11.5.2007/528</ref>.
+                                </i>
+                            </p>
+                        </content>
+                    </section>
+                </chapter>
+                <chapter eId="chp_5">
+                    <num>5 luku</num>
+                    <heading eId="chp_5__heading">Henkilötietojen siirto Euroopan unionin ulkopuolelle</heading>
+                    <section eId="chp_5__sec_22">
+                        <num>22 §</num>
+                        <heading eId="chp_5__sec_22__heading">Yleiset edellytykset</heading>
+                        <subsection eId="chp_5__sec_22__subsec_1">
+                            <content>
+                                <p>Henkilötietoja voidaan siirtää Euroopan unionin jäsenvaltioiden alueen tai Euroopan talousalueen ulkopuolelle ainoastaan, jos kyseisessä maassa taataan tietosuojan riittävä taso.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_22__subsec_2">
+                            <content>
+                                <p>Tietosuojan tason riittävyys on arvioitava ottaen huomioon tietojen luonne, suunnitellun käsittelyn tarkoitus ja kestoaika, alkuperämaa ja lopullinen kohde, asianomaisessa maassa voimassa olevat yleiset ja alakohtaiset oikeussäännöt sekä käytännesäännöt ja noudatettavat turvatoimet.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_22av20000986" finlex:originalVersion="@20000986" finlex:originalVersionLabel="24.11.2000/986">
+                        <num>22 a §</num>
+                        <heading eId="chp_5__sec_22av20000986__heading">Komission päätökset</heading>
+                        <subsection eId="chp_5__sec_22av20000986__subsec_1v20000986">
+                            <content>
+                                <p>Henkilötietoja voidaan siirtää Euroopan unionin jäsenvaltioiden alueen tai Euroopan talousalueen ulkopuolelle siltä osin kuin Euroopan yhteisöjen komissio on yksilöiden suojelusta henkilötietojen käsittelyssä ja näiden tietojen vapaasta liikkuvuudesta annetun Euroopan parlamentin ja neuvoston direktiivin 95/46/EY, jäljempänä henkilötietodirektiivi, 3 artiklan ja 25 artiklan 6 kohdan mukaisesti todennut, että kyseisessä maassa taataan tietosuojan riittävä taso.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_22av20000986__subsec_2v20000986">
+                            <content>
+                                <p>Henkilötietoja ei voida siirtää Euroopan unionin jäsenvaltioiden alueen tai Euroopan talousalueen ulkopuolelle siltä osin kuin komissio on henkilötietodirektiivin 3 artiklan ja 25 artiklan 4 kohdan mukaisesti todennut, että kyseisessä maassa ei taata tietosuojan riittävää tasoa.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_23">
+                        <num>23 §</num>
+                        <heading eId="chp_5__sec_23__heading">Poikkeusperusteet</heading>
+                        <subsection eId="chp_5__sec_23__subsec_1">
+                            <intro eId="chp_5__sec_23__subsec_1__intro" finlex:originalVersion="@20000986" finlex:originalVersionLabel="24.11.2000/986">
+                                <p>Silloin kun siirto ei ole mahdollinen 22 tai 22 a §:n nojalla, voidaan henkilötietoja kuitenkin siirtää, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_23__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>rekisteröity on antanut yksiselitteisen suostumuksensa siirtoon;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_23__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>siirto on tarpeen rekisteröidyn toimeksiannosta tai rekisteröidyn ja rekisterinpitäjän välisen sopimuksen täytäntöönpanemiseksi tai sopimusta edeltävien toimenpiteiden toteuttamiseksi rekisteröidyn pyynnöstä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_23__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>siirto on tarpeen rekisterinpitäjän ja sivullisen välisen rekisteröidyn edun mukaisen sopimuksen tekemiseksi tai täytäntöönpanemiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_23__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>siirto on tarpeen rekisteröidyn elintärkeän edun suojaamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_23__subsec_1__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>siirto on tarpeen tai lain vaatima tärkeän yleisen edun turvaamiseksi tai oikeusvaateen laatimiseksi, esittämiseksi, puolustamiseksi tai ratkaisemiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_23__subsec_1__para_6v20000986" finlex:originalVersion="@20000986" finlex:originalVersionLabel="24.11.2000/986">
+                                <num>6)</num>
+                                <content>
+                                    <p>siirto tehdään rekisteristä, josta yleinen tai erityisin perustein tapahtuva tiedonsaanti on nimenomaisesti säädetty;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_23__subsec_1__para_7v20000986" finlex:originalVersion="@20000986" finlex:originalVersionLabel="24.11.2000/986">
+                                <num>7)</num>
+                                <content>
+                                    <p>rekisterinpitäjä antaa sopimuslausekkein tai muulla tavoin riittävät takeet henkilöiden yksityisyyden ja oikeuksien suojasta, eikä komissio ole henkilötietodirektiivin 3 artiklan ja 26 artiklan 3 kohdan mukaisesti todennut takeita riittämättömiksi; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_23__subsec_1__para_8v20000986" finlex:originalVersion="@20000986" finlex:originalVersionLabel="24.11.2000/986">
+                                <num>8)</num>
+                                <content>
+                                    <p>siirto tapahtuu henkilötietodirektiivin 26 artiklan 4 kohdassa tarkoitettuja komission hyväksymiä mallisopimuslausekkeita käyttäen.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_6">
+                    <num>6 luku</num>
+                    <heading eId="chp_6__heading">Rekisteröidyn oikeudet</heading>
+                    <section eId="chp_6__sec_24">
+                        <num>24 §</num>
+                        <heading eId="chp_6__sec_24__heading">Informointi tietojen käsittelystä</heading>
+                        <subsection eId="chp_6__sec_24__subsec_1">
+                            <content>
+                                <p>Rekisterinpitäjän on henkilötietoja kerätessään huolehdittava siitä, että rekisteröity voi saada tiedon rekisterinpitäjästä ja tarvittaessa tämän edustajasta, henkilötietojen käsittelyn tarkoituksesta sekä siitä, mihin tietoja säännönmukaisesti luovutetaan, samoin kuin ne tiedot, jotka ovat tarpeen rekisteröidyn oikeuksien käyttämiseksi asianomaisessa henkilötietojen käsittelyssä. Tiedot on annettava henkilötietoja kerättäessä ja talletettaessa tai, jos tiedot hankitaan muualta kuin rekisteröidyltä itseltään ja tietoja on tarkoitus luovuttaa, viimeistään silloin kun tietoja ensi kerran luovutetaan.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_24__subsec_2">
+                            <intro eId="chp_6__sec_24__subsec_2__intro">
+                                <p>Edellä 1 momentissa säädetystä tiedonantovelvollisuudesta voidaan poiketa:</p>
+                            </intro>
+                            <paragraph eId="chp_6__sec_24__subsec_2__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>jos rekisteröity on jo saanut nämä tiedot;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_6__sec_24__subsec_2__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>jos se on välttämätöntä valtion turvallisuuden, puolustuksen tai yleisen järjestyksen ja turvallisuuden vuoksi, rikosten ehkäisemiseksi tai selvittämiseksi taikka verotukseen tai julkiseen talouteen liittyvän valvontatehtävän vuoksi; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_6__sec_24__subsec_2__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>kerättäessä tietoja muualta kuin rekisteröidyltä itseltään, jos tietojen antaminen rekisteröidylle on mahdotonta tai vaatii kohtuutonta vaivaa taikka aiheuttaa rekisteröidylle tai tietojenkäsittelyn tarkoitukselle olennaista vahinkoa tai haittaa eikä talletettavia tietoja käytetä rekisteröityä koskevaan päätöksentekoon taikka jos tietojen keräämisestä, tallettamisesta tai luovuttamisesta on nimenomaisesti säädetty.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_25">
+                        <num>25 §</num>
+                        <heading eId="chp_6__sec_25__heading">Informointi tietojen käsittelystä tietyissä tapauksissa</heading>
+                        <subsection eId="chp_6__sec_25__subsec_1v20070528">
+                            <content>
+                                <p>
+                                    <i>
+                                        1–2 momentit on kumottu L:lla 
+                                        <ref href="#entryIntoForce_20070528">11.5.2007/528</ref>.
+                                    </i>
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_25__subsec_3">
+                            <content>
+                                <p>Suoramainoksessa, etämyynnissä ja muussa suoramarkkinoinnissa sekä markkina- ja mielipidetutkimuksen kyselyssä ja muussa näihin rinnastettavassa osoitteellisessa lähetyksessä, jota varten henkilön nimi- ja yhteystiedot on hankittu henkilörekisteristä, on ilmoitettava tiedonhankinnassa käytetyn henkilörekisterin nimi, rekisterinpitäjä ja tämän yhteystiedot. Puhelinmyynnissä vastaavat tiedot on annettava pyynnöstä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_26">
+                        <num>26 §</num>
+                        <heading eId="chp_6__sec_26__heading">Tarkastusoikeus</heading>
+                        <subsection eId="chp_6__sec_26__subsec_1">
+                            <content>
+                                <p>Jokaisella on salassapitosäännösten estämättä oikeus tiedon etsimiseksi tarpeelliset seikat ilmoitettuaan saada tietää, mitä häntä koskevia tietoja henkilörekisteriin on talletettu tai, ettei rekisterissä ole häntä koskevia tietoja. Rekisterinpitäjän on samalla ilmoitettava rekisteröidylle rekisterin säännönmukaiset tietolähteet sekä, mihin rekisterin tietoja käytetään ja säännönmukaisesti luovutetaan. Silloin kun on kysymys 31 §:ssä tarkoitetusta automatisoidusta päätöksestä, rekisteröidyllä on oikeus saada tieto myös tietojen automaattiseen käsittelyyn liittyvistä toimintaperiaatteista.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_26__subsec_2v20070528">
+                            <content>
+                                <p>
+                                    <i>
+                                        2 momentti on kumottu L:lla 
+                                        <ref href="#entryIntoForce_20070528">11.5.2007/528</ref>.
+                                    </i>
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_26__subsec_3">
+                            <content>
+                                <p>Rekisterinpitäjä saa periä tietojen antamisesta korvauksen vain, jos siitä, kun asianomainen edellisen kerran sai tarkastettavakseen rekisterin tiedot, on kulunut vähemmän kuin yksi vuosi. Perittävän korvauksen tulee olla kohtuullinen eikä se saa ylittää tiedon antamisesta aiheutuvia välittömiä kustannuksia.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_27">
+                        <num>27 §</num>
+                        <heading eId="chp_6__sec_27__heading">Tarkastusoikeuden rajoitukset</heading>
+                        <subsection eId="chp_6__sec_27__subsec_1">
+                            <intro eId="chp_6__sec_27__subsec_1__intro">
+                                <p>Edellä 26 §:ssä tarkoitettua tarkastusoikeutta ei ole, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_6__sec_27__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>tiedon antaminen saattaisi vahingoittaa valtion turvallisuutta, puolustusta tai yleistä järjestystä ja turvallisuutta taikka haitata rikosten ehkäisemistä tai selvittämistä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_6__sec_27__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>tiedon antamisesta saattaisi aiheutua vakavaa vaaraa rekisteröidyn terveydelle tai hoidolle taikka jonkun muun oikeuksille;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_6__sec_27__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>rekisterissä olevia henkilötietoja käytetään yksinomaan historiallista tai tieteellistä tutkimusta taikka tilastointia varten; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_6__sec_27__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>rekisterissä olevia henkilötietoja käytetään valvonta- ja tarkastustehtävissä ja tiedon antamatta jättäminen on välttämätöntä Suomen tai Euroopan unionin tärkeän taloudellisen tai rahoituksellisen edun turvaamiseksi.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_6__sec_27__subsec_2">
+                            <content>
+                                <p>Jos vain osa rekisteröityä koskevista tiedoista on sellaisia, että ne 1 momentin mukaan jäävät tarkastusoikeuden ulkopuolelle, rekisteröidyllä on oikeus saada tietää muut hänestä talletetut tiedot.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_28">
+                        <num>28 §</num>
+                        <heading eId="chp_6__sec_28__heading">Tarkastusoikeuden toteuttaminen</heading>
+                        <subsection eId="chp_6__sec_28__subsec_1">
+                            <content>
+                                <p>Sen, joka haluaa tarkastaa itseään koskevat tiedot 26 §:ssä tarkoitetulla tavalla, on esitettävä tätä tarkoittava pyyntö rekisterinpitäjälle omakätisesti allekirjoitetussa tai sitä vastaavalla tavalla varmennetussa asiakirjassa tai henkilökohtaisesti rekisterinpitäjän luona.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_28__subsec_2">
+                            <content>
+                                <p>Rekisterinpitäjän on ilman aiheetonta viivytystä varattava rekisteröidylle tilaisuus tutustua 26 §:ssä tarkoitettuihin tietoihin tai annettava tiedot pyydettäessä kirjallisesti. Tiedot on annettava ymmärrettävässä muodossa. Jos rekisterinpitäjä kieltäytyy antamasta tietoja, hänen on annettava tästä kirjallinen todistus. Todistuksessa on mainittava myös ne syyt, joiden vuoksi tarkastusoikeus on evätty. Tarkastusoikeuden epäämisen veroisena pidetään sitä, että rekisterinpitäjä ei ole kolmen kuukauden kuluessa pyynnön esittämisestä antanut kirjallista vastausta rekisteröidylle. Rekisteröity voi saattaa asian tietosuojavaltuutetun käsiteltäväksi.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_28__subsec_3">
+                            <content>
+                                <p>Sen, joka haluaa tietää, mitä häntä koskevia tietoja on talletettu terveydenhuollon viranomaisen tai laitoksen, lääkärin tai hammaslääkärin taikka muun terveydenhuollon ammattihenkilön pitämään, terveydentilaa tai sairautta koskevia henkilötietoja sisältävään rekisteriin, tulee tehdä pyyntö tarkastusoikeutensa käyttämisestä lääkärille tai muulle terveydenhuollon ammattihenkilölle, joka huolehtii tietojen hankkimisesta rekisteröidyn suostumuksella ja antaa tälle tiedon rekisterissä olevista merkinnöistä. Menettelystä tarkastusoikeuden toteuttamisessa tai sen epäämisessä on voimassa, mitä 2 momentissa säädetään.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_29">
+                        <num>29 §</num>
+                        <heading eId="chp_6__sec_29__heading">Tiedon korjaaminen</heading>
+                        <subsection eId="chp_6__sec_29__subsec_1">
+                            <content>
+                                <p>Rekisterinpitäjän on ilman aiheetonta viivytystä oma-aloitteisesti tai rekisteröidyn vaatimuksesta oikaistava, poistettava tai täydennettävä rekisterissä oleva, käsittelyn tarkoituksen kannalta virheellinen, tarpeeton, puutteellinen tai vanhentunut henkilötieto. Rekisterinpitäjän on myös estettävä tällaisen tiedon leviäminen, jos tieto voi vaarantaa rekisteröidyn yksityisyyden suojaa tai hänen oikeuksiaan.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_29__subsec_2">
+                            <content>
+                                <p>Jollei rekisterinpitäjä hyväksy rekisteröidyn vaatimusta tiedon korjaamisesta, hänen on annettava asiasta kirjallinen todistus. Todistuksessa on mainittava myös ne syyt, joiden vuoksi vaatimusta ei ole hyväksytty. Rekisteröity voi saattaa asian tietosuojavaltuutetun käsiteltäväksi.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_29__subsec_3">
+                            <content>
+                                <p>Rekisterinpitäjän on ilmoitettava tiedon korjaamisesta sille, jolle rekisterinpitäjä on luovuttanut tai jolta rekisterinpitäjä on saanut virheellisen henkilötiedon. Ilmoitusvelvollisuutta ei kuitenkaan ole, jos ilmoittaminen on mahdotonta tai vaatii kohtuutonta vaivaa.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_30">
+                        <num>30 §</num>
+                        <heading eId="chp_6__sec_30__heading">Kielto-oikeus</heading>
+                        <subsection eId="chp_6__sec_30__subsec_1">
+                            <content>
+                                <p>Rekisteröidyllä on oikeus kieltää rekisterinpitäjää käsittelemästä häntä itseään koskevia tietoja suoramainontaa, etämyyntiä ja muuta suoramarkkinointia sekä markkina- ja mielipidetutkimusta samoin kuin henkilömatrikkelia ja sukututkimusta varten.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_31">
+                        <num>31 §</num>
+                        <heading eId="chp_6__sec_31__heading">Automatisoitu päätös</heading>
+                        <subsection eId="chp_6__sec_31__subsec_1">
+                            <intro eId="chp_6__sec_31__subsec_1__intro">
+                                <p>Sellaisen rekisteröidyn tiettyjen ominaisuuksien arviointiin tarkoitetun päätöksen tekeminen, joka tapahtuu ainoastaan automatisoidun tietojenkäsittelyn perusteella ja josta aiheutuu rekisteröidylle oikeudellisia vaikutuksia tai joka muuten vaikuttaa häneen merkittävällä tavalla, on sallittu vain, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_6__sec_31__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>siitä on laissa säädetty; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_6__sec_31__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>päätös tehdään sopimuksen tekemisen tai täytäntöönpanon yhteydessä edellytyksellä, että rekisteröidyn oikeuksien suojaaminen varmistetaan tai että päätöksellä täytetään rekisteröidyn sopimuksen tekemistä tai täytäntöönpanoa koskeva pyyntö.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_7">
+                    <num>7 luku</num>
+                    <heading eId="chp_7__heading">Tietoturvallisuus ja tietojen säilytys</heading>
+                    <section eId="chp_7__sec_32">
+                        <num>32 §</num>
+                        <heading eId="chp_7__sec_32__heading">Tietojen suojaaminen</heading>
+                        <subsection eId="chp_7__sec_32__subsec_1">
+                            <content>
+                                <p>Rekisterinpitäjän on toteutettava tarpeelliset tekniset ja organisatoriset toimenpiteet henkilötietojen suojaamiseksi asiattomalta pääsyltä tietoihin ja vahingossa tai laittomasti tapahtuvalta tietojen hävittämiseltä, muuttamiselta, luovuttamiselta, siirtämiseltä taikka muulta laittomalta käsittelyltä. Toimenpiteiden toteuttamisessa on otettava huomioon käytettävissä olevat tekniset mahdollisuudet, toimenpiteiden aiheuttamat kustannukset, käsiteltävien tietojen laatu, määrä ja ikä sekä käsittelyn merkitys yksityisyyden suojan kannalta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_7__sec_32__subsec_2v20070528" finlex:originalVersion="@20070528" finlex:originalVersionLabel="11.5.2007/528">
+                            <content>
+                                <p>Sen, joka itsenäisenä elinkeinonharjoittajana toimii rekisterinpitäjän lukuun tai jolle rekisterinpitäjä luovuttaa tietoja teknisen käyttöyhteyden avulla, on ennen tietojen käsittelyyn ryhtymistä annettava rekisterinpitäjälle asianmukaiset selvitykset ja sitoumukset sekä muutoin riittävät takeet henkilötietojen suojaamisesta 1 momentissa tarkoitetulla tavalla.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_7__sec_33">
+                        <num>33 §</num>
+                        <heading eId="chp_7__sec_33__heading">Vaitiolovelvollisuus</heading>
+                        <subsection eId="chp_7__sec_33__subsec_1">
+                            <content>
+                                <p>Joka henkilötietojen käsittelyyn liittyviä toimenpiteitä suorittaessaan on saanut tietää jotakin toisen henkilön ominaisuuksista, henkilökohtaisista oloista tai taloudellisesta asemasta, ei saa tämän lain vastaisesti sivulliselle ilmaista näin saamiaan tietoja.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_7__sec_34">
+                        <num>34 §</num>
+                        <heading eId="chp_7__sec_34__heading">Henkilörekisterin hävittäminen</heading>
+                        <subsection eId="chp_7__sec_34__subsec_1">
+                            <content>
+                                <p>Henkilörekisteri, joka ei ole enää rekisterinpitäjän toiminnan kannalta tarpeellinen, on hävitettävä, jollei siihen talletettuja tietoja ole erikseen säädetty tai määrätty säilytettäviksi tai jollei rekisteriä siirretä 35 §:ssä tarkoitetulla tavalla arkistoon.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_7__sec_35">
+                        <num>35 §</num>
+                        <heading eId="chp_7__sec_35__heading">Henkilötietojen siirto arkistoon</heading>
+                        <subsection eId="chp_7__sec_35__subsec_1">
+                            <content>
+                                <p>Arkistolaitokseen tai siihen verrattavaan arkistoon siirrettyjen henkilörekistereiden käytöstä ja suojaamisesta sekä niissä olevien tietojen luovuttamisesta on voimassa, mitä erikseen säädetään. Arkistolaitoksen tai siihen verrattavan arkiston on kuitenkin henkilötietoja yksityisistä henkilörekistereistä luovutettaessa otettava huomioon, mitä tässä laissa säädetään henkilötietojen käsittelystä ja luovuttamisesta, jollei se henkilörekisteriin talletettujen tietojen ikä ja laatu huomioon ottaen ole rekisteröityjen yksityisyyden suojan vuoksi ilmeisen tarpeetonta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_7__sec_35__subsec_2">
+                            <content>
+                                <p>Henkilörekisteri, joka on tieteellisen tutkimuksen kannalta tai muusta syystä merkityksellinen, voidaan siirtää korkeakoulun taikka tutkimustyötä lakisääteisenä tehtävänä suorittavan laitoksen tai viranomaisen arkistoon, jos kansallisarkisto on antanut siihen luvan. Kansallisarkisto voi antaa yhteisölle, säätiölle ja laitokselle luvan siirtää arkistoonsa omassa toiminnassa syntyneitä henkilörekistereitä, jotka täyttävät edellä mainitut vaatimukset. Kansallisarkiston on päätöksessään määrättävä, miten rekistereiden suojaus on järjestettävä sekä miten henkilötietojen käyttöä on valvottava.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_7__sec_35__subsec_3">
+                            <content>
+                                <p>Kansallisarkiston on ennen 2 momentissa tarkoitetun luvan antamista varattava tietosuojavaltuutetulle tilaisuus lausunnon antamiseen.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_8">
+                    <num>8 luku</num>
+                    <heading eId="chp_8__heading">Ilmoitus tietosuojavaltuutetulle</heading>
+                    <section eId="chp_8__sec_36">
+                        <num>36 §</num>
+                        <heading eId="chp_8__sec_36__heading">Ilmoitusvelvollisuus</heading>
+                        <subsection eId="chp_8__sec_36__subsec_1">
+                            <content>
+                                <p>Rekisterinpitäjän on ilmoitettava henkilötietojen automaattisesta käsittelystä tietosuojavaltuutetulle lähettämällä tälle rekisteriseloste.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_8__sec_36__subsec_2">
+                            <intro eId="chp_8__sec_36__subsec_2__intro">
+                                <p>Lisäksi rekisterinpitäjän on ilmoitettava tietosuojavaltuutetulle:</p>
+                            </intro>
+                            <paragraph eId="chp_8__sec_36__subsec_2__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>henkilötietojen siirrosta Euroopan unionin jäsenvaltioiden alueen tai Euroopan talousalueen ulkopuolelle, jos tietoja siirretään 22 §:n nojalla tai 23 §:n 6 tai 7 kohdassa tarkoitetuilla perusteilla eikä siirrosta ole laissa säädetty; sekä</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_8__sec_36__subsec_2__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>31 §:ssä tarkoitetun automatisoidun päätöksentekojärjestelmän käyttöönotosta.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_8__sec_36__subsec_3v20070528" finlex:originalVersion="@20070528" finlex:originalVersionLabel="11.5.2007/528">
+                            <content>
+                                <p>
+                                    Joka harjoittaa elinkeinona perimistoimintaa tai markkina- tai mielipidetutkimusta taikka hoitaa toisen lukuun henkilöstön valintaan ja soveltuvuuden arviointiin liittyviä tehtäviä tai tietojenkäsittelytehtäviä ja tässä toiminnassa käyttää tai käsittelee henkilörekistereitä ja niissä olevia tietoja, on velvollinen tekemään ilmoituksen toiminnastaan tietosuojavaltuutetulle. Velvollisuudesta tehdä ilmoitus luottotietotoiminnan harjoittamisesta säädetään luottotietolaissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/2007/527">(527/2007)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_8__sec_36__subsec_4">
+                            <content>
+                                <p>Edellä 1 momentissa tarkoitettua ilmoitusvelvollisuutta ei ole, jos henkilötietojen käsittely perustuu 8 §:n 1 momentin 1–3 kohtaan, 4 kohtaan, jos käsittelystä säädetään laissa, 5 kohdassa tarkoitettuun asiakas- tai palvelussuhteeseen tai jäsenyyteen tai 6 tai 9 kohtaan taikka 12 §:n 1–4 kohtaan, 5 kohtaan, jos käsittelystä säädetään laissa, tai 7–10, 12 tai 13 kohtaan taikka 13–18 tai 20 §:ään. Ilmoitusvelvollisuudesta voidaan lisäksi poiketa, sen mukaan kuin asetuksella säädetään, jos on ilmeistä, ettei henkilötietojen käsittely loukkaa rekisteröidyn yksityisyyden suojaa taikka hänen oikeuksiaan tai vapauksiaan.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <hcontainer eId="note_2" finlex:outline="huomautus" name="noteAuthorial">
+                        <content>
+                            <p>
+                                20 § on kumottu L:lla 
+                                <ref href="/akn/fi/act/statute/2007/528">528/2007</ref>. Ks. L tietosuojalautakunnasta ja tietosuojavaltuutetusta 
+                                <ref href="/akn/fi/act/statute-consolidated/1994/389#sec_5">389/1994 5 §</ref>, A tietosuojalautakunnasta ja tietosuojavaltuutetusta 
+                                <ref href="/akn/fi/act/statute-consolidated/1994/432#sec_10b">432/1994 10 b §</ref>
+                                 sekä LuottotietoL 
+                                <ref href="/akn/fi/act/statute-consolidated/2007/527#sec_38">527/2007 38 §</ref>.
+                            </p>
+                        </content>
+                    </hcontainer>
+                    <section eId="chp_8__sec_37">
+                        <num>37 §</num>
+                        <heading eId="chp_8__sec_37__heading">Ilmoituksen tekeminen</heading>
+                        <subsection eId="chp_8__sec_37__subsec_1">
+                            <content>
+                                <p>Edellä 36 §:n 2 momentin 1 kohdassa tarkoitetusta ilmoituksesta tulee käydä ilmi rekisteriselosteeseen sisältyvien tietojen lisäksi, mitä tietotyyppejä siirretään ja miten siirto tapahtuu.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_8__sec_37__subsec_2">
+                            <content>
+                                <p>Edellä 36 §:n 2 momentin 2 kohdassa tarkoitetusta ilmoituksesta tulee käydä ilmi rekisteriselosteeseen sisältyvien tietojen lisäksi järjestelmässä käytetty logiikka.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_8__sec_37__subsec_3">
+                            <content>
+                                <p>Edellä 36 §:n 3 momentissa tarkoitetusta ilmoituksesta tulee käydä ilmi elinkeinonharjoittajan nimi, toimiala, kotipaikka ja yhteystiedot, toiminnassa käytettävät henkilörekisterit ja niiden sisältämät tietotyypit, tietojen mahdollinen luovuttaminen rekisteristä ja talletettujen tietojen säilytysaika, miten henkilörekistereiden suojaus on järjestetty ja miten niiden käyttöä valvotaan.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_8__sec_37__subsec_4">
+                            <content>
+                                <p>Ilmoitus on tehtävä riittävän ajoissa, kuitenkin viimeistään 30 päivää ennen henkilörekisteriin talletettaviksi aiottujen henkilötietojen keräämistä ja tallettamista tai muuhun ilmoitusvelvollisuuden aiheuttavaan toimenpiteeseen ryhtymistä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_9">
+                    <num>9 luku</num>
+                    <heading eId="chp_9__heading">Henkilötietojen käsittelyn ohjaus ja valvonta</heading>
+                    <section eId="chp_9__sec_38">
+                        <num>38 §</num>
+                        <heading eId="chp_9__sec_38__heading">Tietosuojaviranomaiset</heading>
+                        <subsection eId="chp_9__sec_38__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutettu antaa henkilötietojen käsittelyä koskevaa ohjausta ja neuvontaa sekä valvoo henkilötietojen käsittelyä tämän lain tavoitteiden toteuttamiseksi ja käyttää päätösvaltaa siten kuin tässä laissa säädetään.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_38__subsec_2">
+                            <content>
+                                <p>Tietosuojalautakunta käsittelee henkilötietojen käsittelyyn liittyviä lain soveltamisalan kannalta periaatteellisesti tärkeitä kysymyksiä ja käyttää päätösvaltaa tietosuoja-asioissa siten kuin tässä laissa säädetään.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_38__subsec_3">
+                            <content>
+                                <p>Tietosuojaviranomaiset voivat käyttää tässä luvussa tarkoitettuja toimivaltuuksia silloinkin, kun henkilötietojen käsittelyyn ei 4 §:n mukaisesti sovelleta tätä lakia. Tietosuojaviranomaiset toimivat yhteistyössä muiden Euroopan unionin jäsenvaltioiden tietosuojaviranomaisten kanssa ja antavat tarvittaessa virka-apua.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_9__sec_39">
+                        <num>39 §</num>
+                        <heading eId="chp_9__sec_39__heading">Tietosuojaviranomaisten tiedonsaanti- ja tarkastusoikeus</heading>
+                        <subsection eId="chp_9__sec_39__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetulla on oikeus salassapitosäännösten estämättä saada tiedot käsiteltävistä henkilötiedoista sekä kaikki tiedot, jotka ovat tarpeen henkilötietojen käsittelyn lainmukaisuuden valvonnassa. Tietosuojalautakunnalla on vastaava oikeus sen käsiteltävissä asioissa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_39__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutetulla on oikeus tarkastaa henkilörekistereitä ja käyttää tarkastuksessa asiantuntijoita. Tarkastuksen toimittamista varten tietosuojavaltuutetulla ja asiantuntijalla on oikeus päästä sellaisiin rekisterinpitäjän ja hänen toimeksiannostaan toimivan hallussa oleviin huoneistoihin, joissa henkilötietoja käsitellään tai henkilörekistereitä pidetään, sekä saada käytettäväkseen tarkastuksen toimittamisessa tarvittavat tiedot ja laitteet. Kotirauhan piiriin kuuluvassa tilassa tarkastuksen saa toimittaa vain, jos esillä olevassa tapauksessa on olemassa yksilöity syy epäillä henkilötietojen käsittelyä koskevia säännöksiä rikotun tai rikottavan. Tarkastus on toimitettava niin, että siitä ei aiheudu rekisterinpitäjälle tarpeettomasti haittaa ja kustannuksia.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_39__subsec_3">
+                            <content>
+                                <p>Edellä 2 §:n 5 momentissa tarkoitetun käsittelyn osalta tietosuojavaltuutettu valvoo 32 §:ssä säädetyn tietojen suojaamisvelvollisuuden noudattamista. Tietosuojavaltuutetulla on oikeus tässä tarkoituksessa saada tarpeellisia tietoja rekistereiden suojaamisesta.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_9__sec_40">
+                        <num>40 §</num>
+                        <heading eId="chp_9__sec_40__heading">Tietosuojavaltuutetun toimenpiteet</heading>
+                        <subsection eId="chp_9__sec_40__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun on edistettävä hyvää tietojenkäsittelytapaa sekä ohjein ja neuvoin pyrittävä siihen, että lainvastaista menettelyä ei jatketa tai uusita. Tarvittaessa tietosuojavaltuutetun on saatettava asia tietosuojalautakunnan päätettäväksi taikka ilmoitettava se syytteeseen panoa varten.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_40__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutetun on ratkaistava asia, jonka rekisteröity on saattanut 28 ja 29 §:n nojalla hänen käsiteltäväkseen. Tietosuojavaltuutettu voi antaa rekisterinpitäjälle määräyksen rekisteröidyn tarkastusoikeuden toteuttamisesta tai tiedon korjaamisesta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_40__subsec_3">
+                            <content>
+                                <p>Tietosuojavaltuutettu voi antaa tarkempia ohjeita siitä, miten henkilötiedot on suojattava henkilötietojen laittomalta käsittelyltä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_9__sec_41">
+                        <num>41 §</num>
+                        <heading eId="chp_9__sec_41__heading">Tietosuojavaltuutetun kuuleminen</heading>
+                        <subsection eId="chp_9__sec_41__subsec_1">
+                            <content>
+                                <p>Asianomaisen viranomaisen on varattava tietosuojavaltuutetulle tilaisuus tulla kuulluksi valmisteltaessa lainsäädännöllisiä tai hallinnollisia uudistuksia, jotka koskevat henkilöiden oikeuksien ja vapauksien suojaamista henkilötietojen käsittelyssä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_41__subsec_2v20110457" finlex:originalVersion="@20110457" finlex:originalVersionLabel="13.5.2011/457">
+                            <content>
+                                <p>Syyttäjän on ennen tämän lain vastaista menettelyä koskevan syytteen nostamista kuultava tietosuojavaltuutettua. Tuomioistuimen on tällaista asiaa käsitellessään varattava tietosuojavaltuutetulle tilaisuus tulla kuulluksi.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_9__sec_42">
+                        <num>42 §</num>
+                        <heading eId="chp_9__sec_42__heading">Toimialakohtaiset käytännesäännöt</heading>
+                        <subsection eId="chp_9__sec_42__subsec_1">
+                            <content>
+                                <p>Rekisterinpitäjät tai näitä edustavat yhteisöt voivat laatia toimialakohtaisia käytännesääntöjä tämän lain soveltamiseksi ja hyvän tietojenkäsittelytavan edistämiseksi sekä toimittaa laatimansa ehdotukset tietosuojavaltuutetulle. Tietosuojavaltuutettu voi tarkastaa, että käytännesäännöt ovat tämän lain ja muiden henkilötietojen käsittelyyn vaikuttavien säännösten mukaisia.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_9__sec_43">
+                        <num>43 §</num>
+                        <heading eId="chp_9__sec_43__heading">Tietosuojalautakunnan lupatoimivalta</heading>
+                        <subsection eId="chp_9__sec_43__subsec_1">
+                            <content>
+                                <p>Tietosuojalautakunta voi antaa 8 §:n 1 momentin 9 kohdassa tarkoitetun luvan henkilötietojen käsittelyyn, jos käsittely on tarpeen rekisteröidyn elintärkeän edun suojaamiseksi muussa kuin yksittäistapauksessa taikka yleistä etua koskevan tehtävän suorittamiseksi tai sellaisen julkisen vallan käyttämiseksi, joka kuuluu rekisterinpitäjälle tai sivulliselle, jolle tiedot luovutetaan. Lupa voidaan myöntää myös rekisterinpitäjän tai tiedot saavan sivullisen oikeutetun edun toteuttamiseksi edellyttäen, ettei tietojen tällainen käsittely vaaranna henkilön yksityisyyden suojaa ja oikeuksia.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_43__subsec_2">
+                            <content>
+                                <p>Tietosuojalautakunta voi antaa 12 §:n 13 kohdassa tarkoitetun luvan arkaluonteisten henkilötietojen käsittelyyn tärkeää yleistä etua koskevasta syystä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_43__subsec_3">
+                            <content>
+                                <p>Lupa voidaan antaa määräajaksi tai toistaiseksi ja siihen on liitettävä rekisteröidyn yksityisyyden suojaamiseksi tarpeelliset määräykset. Määräyksiä voidaan tietosuojavaltuutetun tai luvan saajan hakemuksesta muuttaa tai täydentää, jos se muuttuneiden olosuhteiden vuoksi on tarpeen.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_9__sec_44">
+                        <num>44 §</num>
+                        <heading eId="chp_9__sec_44__heading">Tietosuojalautakunnan määräykset</heading>
+                        <subsection eId="chp_9__sec_44__subsec_1">
+                            <intro eId="chp_9__sec_44__subsec_1__intro">
+                                <p>Tietosuojalautakunta voi tietosuojavaltuutetun hakemuksesta: </p>
+                            </intro>
+                            <paragraph eId="chp_9__sec_44__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>kieltää tämän lain tai sen nojalla annettujen säännösten ja määräysten vastaisen henkilötietojen käsittelyn;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_9__sec_44__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>velvoittaa muissa kuin 40 §:n 2 momentissa tarkoitetuissa asioissa asianomaisen määräajassa oikaisemaan sen, mitä on oikeudettomasti tehty tai laiminlyöty;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_9__sec_44__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>määrätä rekisteritoiminnan lopetettavaksi, jos lainvastaiset toimet tai laiminlyönnit huomattavasti vaarantavat rekisteröidyn yksityisyyden suojaa tai hänen etujaan tai oikeuksiaan, jollei rekisteristä ole laissa säädetty; sekä</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_9__sec_44__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>peruuttaa 43 §:ssä tarkoitetun luvan, kun edellytyksiä luvan myöntämiselle ei enää ole tai kun rekisterinpitäjä toimii luvan tai siihen liitettyjen määräysten vastaisesti.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                    <section eId="chp_9__sec_45v20150901" finlex:originalVersion="@20150901" finlex:originalVersionLabel="7.8.2015/901">
+                        <num>45 §</num>
+                        <heading eId="chp_9__sec_45v20150901__heading">Muutoksenhaku</heading>
+                        <subsection eId="chp_9__sec_45v20150901__subsec_1v20150901">
+                            <content>
+                                <p>
+                                    Tietosuojavaltuutetun ja tietosuojalautakunnan päätökseen saa hakea muutosta valittamalla hallinto-oikeuteen siten kuin hallintolainkäyttölaissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/1996/586">(586/1996)</ref>
+                                     säädetään. Tietosuojavaltuutettu saa hakea muutosta tietosuojalautakunnan 43 §:n nojalla tekemään päätökseen.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_45v20150901__subsec_2v20150901">
+                            <content>
+                                <p>Hallinto-oikeuden päätökseen saa hakea muutosta valittamalla vain, jos korkein hallinto-oikeus myöntää valitusluvan.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_9__sec_45v20150901__subsec_3v20150901">
+                            <content>
+                                <p>Tietosuojalautakunnan päätöksessä voidaan määrätä, että päätöstä on noudatettava muutoksenhausta huolimatta, jollei valitusviranomainen toisin määrää.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_9__sec_46">
+                        <num>46 §</num>
+                        <heading eId="chp_9__sec_46__heading">Uhkasakko</heading>
+                        <subsection eId="chp_9__sec_46__subsec_1">
+                            <content>
+                                <p>
+                                    Tietosuojavaltuutettu voi asettaa 39 §:n 1 ja 3 momentin mukaisen tietojenantovelvollisuuden ja 40 §:n 2 momentin nojalla tekemänsä päätöksen ja tietosuojalautakunta 39 §:n 1 momentin mukaisen tietojenantovelvollisuuden ja 44 §:n nojalla tekemänsä päätöksen tehosteeksi uhkasakon siten kuin uhkasakkolaissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/1990/1113">(1113/1990)</ref>
+                                     säädetään.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_10">
+                    <num>10 luku</num>
+                    <heading eId="chp_10__heading">Erinäiset säännökset</heading>
+                    <section eId="chp_10__sec_47">
+                        <num>47 §</num>
+                        <heading eId="chp_10__sec_47__heading">Vahingonkorvausvelvollisuus</heading>
+                        <subsection eId="chp_10__sec_47__subsec_1">
+                            <content>
+                                <p>Rekisterinpitäjä on velvollinen korvaamaan sen taloudellisen ja muun vahingon, joka on aiheutunut rekisteröidylle tai muulle henkilölle tämän lain vastaisesta henkilötietojen käsittelystä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_10__sec_47__subsec_2">
+                            <content>
+                                <p>
+                                    Vahingonkorvauksesta on muutoin voimassa, mitä vahingonkorvauslain 
+                                    <ref href="/akn/fi/act/statute-consolidated/1974/412#chp_2">(412/1974) 2 luvun</ref>
+                                     2 ja 3 §:ssä, 3 luvun 4 ja 6 §:ssä sekä 4, 6 ja 7 luvussa säädetään.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_10__sec_48">
+                        <num>48 §</num>
+                        <heading eId="chp_10__sec_48__heading">Rangaistussäännökset</heading>
+                        <subsection eId="chp_10__sec_48__subsec_1">
+                            <content>
+                                <p>
+                                    Rangaistus henkilörekisteririkoksesta säädetään rikoslain 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001#chp_38__sec_9">(39/1889) 38 luvun 9 §:ssä</ref>
+                                     ja henkilörekisteriin kohdistuvasta tietomurrosta 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001#chp_38__sec_8">rikoslain 38 luvun 8 §:ssä</ref>. Rangaistus 33 §:ssä säädetyn vaitiolovelvollisuuden rikkomisesta tuomitaan 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001#chp_38">rikoslain 38 luvun</ref>
+                                     1 tai 2 §:n mukaan, jollei teko ole rangaistava 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001#chp_40__sec_5">rikoslain 40 luvun 5 §:n</ref>
+                                     mukaan tai siitä muualla laissa säädetä ankarampaa rangaistusta.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_10__sec_48__subsec_2">
+                            <intro eId="chp_10__sec_48__subsec_2__intro">
+                                <p>Joka tahallaan tai törkeästä huolimattomuudesta tämän lain vastaisesti</p>
+                            </intro>
+                            <paragraph eId="chp_10__sec_48__subsec_2__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>laiminlyö noudattaa, mitä henkilötietojen käsittelyn tarkoitusten määrittelystä, rekisteriselosteen laatimisesta, tietojen käsittelystä, informoimisesta, henkilörekisterissä olevan tiedon korjaamisesta, rekisteröidyn kielto-oikeudesta tai ilmoituksen tekemisestä tietosuojavaltuutetulle säädetään,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_10__sec_48__subsec_2__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>antaa tietosuojaviranomaiselle henkilötietojen käsittelyä koskevassa asiassa väärän tai harhaanjohtavan tiedon,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_10__sec_48__subsec_2__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>rikkoo henkilötietojen suojaamisesta ja henkilörekisterin hävittämisestä annettuja säännöksiä ja määräyksiä taikka</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_10__sec_48__subsec_2__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>rikkoo tietosuojalautakunnan 43 §:n 3 momentin nojalla antamaa lainvoimaista määräystä</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_10__sec_48__subsec_2__para_5">
+                                <content>
+                                    <p>
+                                        ja siten vaarantaa rekisteröidyn yksityisyyden suojaa tai hänen oikeuksiaan, on tuomittava, jollei teosta ole muualla laissa säädetty ankarampaa rangaistusta, 
+                                        <i>henkilörekisteririkkomuksesta</i>
+                                         sakkoon.
+                                    </p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                    </section>
+                    <section eId="chp_10__sec_49">
+                        <num>49 §</num>
+                        <heading eId="chp_10__sec_49__heading">Tarkemmat säännökset</heading>
+                        <subsection eId="chp_10__sec_49__subsec_1">
+                            <content>
+                                <p>Tarkemmat säännökset tämän lain täytäntöönpanosta annetaan asetuksella.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_11" finlex:entryIntoForce="true" finlex:vsId="523/1999">
+                    <num>11 luku</num>
+                    <heading eId="chp_11__heading">Voimaantulo- ja siirtymäsäännökset</heading>
+                    <section eId="chp_11__sec_50">
+                        <num>50 §</num>
+                        <heading eId="chp_11__sec_50__heading">Voimaantulo</heading>
+                        <subsection eId="chp_11__sec_50__subsec_1">
+                            <content>
+                                <p>Tämä laki tulee voimaan 1 päivänä kesäkuuta 1999.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_11__sec_50__subsec_2">
+                            <content>
+                                <p>
+                                    Tällä lailla kumotaan 30 päivänä huhtikuuta 1987 annettu henkilörekisterilaki 
+                                    <ref href="/akn/fi/act/statute/1987/471">(471/1987)</ref>
+                                     siihen myöhemmin tehtyine muutoksineen. Kumotun lain massaluovutuksen ja arkaluonteisen otannan määritelmiä koskevia säännöksiä sovelletaan kuitenkin edelleen, siltä osin kuin muussa lainsäädännössä viitataan niihin, 24 päivään lokakuuta 2001.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_11__sec_50__subsec_3">
+                            <content>
+                                <p>Ennen tämän lain voimaantuloa voidaan ryhtyä sen täytäntöönpanon edellyttämiin toimiin.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_11__sec_51">
+                        <num>51 §</num>
+                        <heading eId="chp_11__sec_51__heading">Siirtymäsäännökset</heading>
+                        <subsection eId="chp_11__sec_51__subsec_1">
+                            <content>
+                                <p>Henkilötietojen käsittely, johon on ryhdytty ennen tämän lain voimaantuloa, on saatettava tämän lain vaatimuksia vastaavaksi viimeistään 24 päivänä lokakuuta 2001.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_11__sec_51__subsec_2">
+                            <content>
+                                <p>Jos muussa lainsäädännössä viitataan tällä lailla kumottuun henkilörekisterilakiin tai sen säännöksiin, viittauksen on katsottava tarkoittavan tätä lakia tai sen vastaavia säännöksiä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+            </hcontainer>
+            <hcontainer finlex:outline="Esityöt ja allekirjoitukset" name="conclusions">
+                <hcontainer finlex:outline="Esityöt" name="preliminaryWork">
+                    <content>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/1998/96">HE 96/1998</ref>
+                        </p>
+                        <p>HaVM 26/1998</p>
+                        <p>EV 278/1998</p>
+                    </content>
+                </hcontainer>
+            </hcontainer>
+            <hcontainer name="amendmentEntryIntoForceAndApplianceProvisions">
+                <heading>Muutossäädösten voimaantulo ja soveltaminen</heading>
+                <hcontainer eId="entryIntoForce_20000986" name="entryIntoForce">
+                    <heading>24.11.2000/986:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä joulukuuta 2000.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2000/137">HE 137/2000</ref>, HaVM 16/2000, EV 144/2000, Euroopan parlamentin ja neuvoston direktiivi 95/46/EY (31995L0046); EYVL N:o L 281, 23.11.1995, s. 31
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20070528" name="entryIntoForce">
+                    <heading>11.5.2007/528:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä marraskuuta 2007.</p>
+                        <p>
+                            2 mom. on kumottu L:lla 
+                            <ref href="#entryIntoForce_20080512">18.7.2008/512</ref>.
+                        </p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2006/241">HE 241/2006</ref>, LaVM 32/2006, EV 315/2006
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20080512" name="entryIntoForce">
+                    <heading>18.7.2008/512:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä syyskuuta 2008.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2008/19">HE 19/2008</ref>, TyVM 3/2008, EV 63/2008
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20100294" name="entryIntoForce">
+                    <heading>30.4.2010/294:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä toukokuuta 2010.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2009/169">HE 169/2009</ref>, TaVM 4/2010, EV 38/2010, Euroopan parlamentin ja neuvoston direktiivi  2007/64/EY (32007L0064) EUVL N:o L 319, 5.12.2007, s.1
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20101049" name="entryIntoForce">
+                    <heading>3.12.2010/1049:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä tammikuuta 2011.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2010/202">HE 202/2010</ref>, HaVM 20/2010, EV 196/2010
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20110457" name="entryIntoForce">
+                    <heading>13.5.2011/457:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 17 päivänä toukokuuta 2011.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2010/286">HE 286/2010</ref>, LaVM 34/2010, EV 311/2010
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20150901" name="entryIntoForce">
+                    <heading>7.8.2015/901:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä tammikuuta 2016.</p>
+                        <p>Muutoksenhaussa ennen tämän lain voimaantuloa annettuun hallintopäätökseen sovelletaan tämän lain voimaan tullessa voimassa olleita säännöksiä.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2014/230">HE 230/2014</ref>, LaVM 26/2014, EV 319/2014
+                        </p>
+                    </content>
+                </hcontainer>
+            </hcontainer>
+        </body>
+    </act>
+</akomaNtoso>

--- a/tests/fixtures/finlex/statute-consolidated-2005-45-fin-contentabsent.xml
+++ b/tests/fixtures/finlex/statute-consolidated-2005-45-fin-contentabsent.xml
@@ -1,0 +1,67 @@
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:finlex="http://data.finlex.fi/schema/finlex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <act contains="multipleVersions" name="main">
+        <meta>
+            <identification source="#organization_fi.finlex">
+                <FRBRWork>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/2005/45/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/2005/45"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2005/45/ajantasa"/>
+                    <FRBRdate date="2005-01-28" name="dateIssued"/>
+                    <FRBRdate date="2005-02-02" name="datePublished"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.finlex"/>
+                    <FRBRcountry value="fi"/>
+                    <FRBRsubtype value="statute-consolidated"/>
+                    <FRBRnumber value="45"/>
+                    <FRBRprescriptive value="false"/>
+                    <FRBRauthoritative value="false"/>
+                </FRBRWork>
+                <FRBRExpression>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/2005/45/fin@/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/2005/45/fin@"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2005/45/ajantasa/2005-01-28/fin"/>
+                    <FRBRdate date="2005-01-28" name="dateIssued"/>
+                    <FRBRdate date="2005-01-28" name="dateConsolidated"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.finlex"/>
+                    <FRBRversionNumber value="20050045"/>
+                    <FRBRlanguage language="fin"/>
+                </FRBRExpression>
+                <FRBRManifestation>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/2005/45/fin@/!main.xml"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/2005/45/fin@.akn"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2005/45/ajantasa/2005-01-28/fin/xml"/>
+                    <FRBRdate date="2026-05-20" name="dateProduced"/>
+                    <FRBRdate date="2005-02-02" name="datePublished"/>
+                    <FRBRauthor as="#role_editor" href="#organization_fi.finlex"/>
+                    <FRBRformat value="xml"/>
+                </FRBRManifestation>
+            </identification>
+            <references source="#organization_fi.finlex">
+                <TLCOrganization eId="organization_fi.finlex" href="/akn/ontology/organization/fi.finlex" showAs="Finlex"/>
+                <TLCRole eId="role_author" href="/akn/ontology/role/author" showAs="Tekijä"/>
+                <TLCRole eId="role_editor" href="/akn/ontology/role/editor" showAs="Toimittaja"/>
+                <TLCOrganization eId="fi.ministry-of-justice" href="/akn/ontology/organization/fi.ministry-of-justice" showAs="Oikeusministeriö"/>
+                <TLCConcept eId="act" href="/akn/ontology/concept/statute/type-statute.act" showAs="Laki"/>
+            </references>
+            <proprietary source="#organization_fi.finlex">
+                <finlex:documentYear>2005</finlex:documentYear>
+                <finlex:administrativeBranch refersTo="#fi.ministry-of-justice"/>
+                <finlex:typeStatute refersTo="#act"/>
+                <finlex:isInForce value="true"/>
+                <finlex:inForce>
+                    <finlex:dateEntryIntoForce date="2005-10-05"/>
+                    <finlex:noteEditorial>ks. A 789/2005</finlex:noteEditorial>
+                </finlex:inForce>
+                <finlex:noteEditorial>ks. soveltamisesta ennen pöytäkirjan kansainvälistä voimaantuloa A 308/2005</finlex:noteEditorial>
+            </proprietary>
+        </meta>
+        <preface>
+            <p>
+                <docNumber>45/2005</docNumber>
+                <docTitle>Laki keskinäisestä oikeusavusta rikosasioissa Euroopan unionin jäsenvaltioiden välillä tehtyyn yleissopimukseen liitettävän pöytäkirjan lainsäädännön alaan kuuluvien määräysten voimaansaattamisesta</docTitle>
+            </p>
+        </preface>
+        <body>
+            <hcontainer name="contentAbsent"/>
+        </body>
+    </act>
+</akomaNtoso>

--- a/tests/fixtures/finlex/statute-consolidated-2018-1050-fin-latest.xml
+++ b/tests/fixtures/finlex/statute-consolidated-2018-1050-fin-latest.xml
@@ -1,0 +1,1334 @@
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:finlex="http://data.finlex.fi/schema/finlex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <act contains="multipleVersions" name="main">
+        <meta>
+            <identification source="#organization_fi.finlex">
+                <FRBRWork>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/2018/1050/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/2018/1050"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/ajantasa"/>
+                    <FRBRdate date="2018-12-05" name="dateIssued"/>
+                    <FRBRdate date="2018-12-10" name="datePublished"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.finlex"/>
+                    <FRBRcountry value="fi"/>
+                    <FRBRsubtype value="statute-consolidated"/>
+                    <FRBRnumber value="1050"/>
+                    <FRBRprescriptive value="false"/>
+                    <FRBRauthoritative value="false"/>
+                </FRBRWork>
+                <FRBRExpression>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/2018/1050/fin@20260380/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/2018/1050/fin@20260380"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/ajantasa/2026-05-22/fin"/>
+                    <FRBRdate date="2018-12-05" name="dateIssued"/>
+                    <FRBRdate date="2026-05-22" name="dateConsolidated"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.finlex"/>
+                    <FRBRversionNumber value="20260380"/>
+                    <FRBRlanguage language="fin"/>
+                </FRBRExpression>
+                <FRBRManifestation>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/2018/1050/fin@20260380/!main.xml"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/2018/1050/fin@20260380.akn"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/ajantasa/2026-05-22/fin/xml"/>
+                    <FRBRdate date="2026-06-01" name="dateProduced"/>
+                    <FRBRdate date="2018-12-10" name="datePublished"/>
+                    <FRBRauthor as="#role_editor" href="#organization_fi.finlex"/>
+                    <FRBRformat value="xml"/>
+                </FRBRManifestation>
+            </identification>
+            <classification source="#organization_fi.finlex">
+                <keyword dictionary="/akn/ontology/concept/statute-keyword" showAs="Tietosuoja" value="/akn/ontology/concept/statute-keyword.3876"/>
+            </classification>
+            <references source="#organization_fi.finlex">
+                <TLCOrganization eId="organization_fi.finlex" href="/akn/ontology/organization/fi.finlex" showAs="Finlex"/>
+                <TLCRole eId="role_author" href="/akn/ontology/role/author" showAs="Tekijä"/>
+                <TLCRole eId="role_editor" href="/akn/ontology/role/editor" showAs="Toimittaja"/>
+                <TLCOrganization eId="fi.ministry-of-justice" href="/akn/ontology/organization/fi.ministry-of-justice" showAs="Oikeusministeriö"/>
+                <TLCConcept eId="act" href="/akn/ontology/concept/statute/type-statute.act" showAs="Laki"/>
+            </references>
+            <proprietary source="#organization_fi.finlex">
+                <finlex:documentYear>2018</finlex:documentYear>
+                <finlex:administrativeBranch refersTo="#fi.ministry-of-justice"/>
+                <finlex:typeStatute refersTo="#act"/>
+                <finlex:isInForce value="true"/>
+                <finlex:inForce>
+                    <finlex:dateEntryIntoForce date="2019-01-01"/>
+                </finlex:inForce>
+                <finlex:repeals>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute-consolidated/1994/389">389/1994</finlex:ref>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute-consolidated/1999/523">523/1999</finlex:ref>
+                    </finlex:statuteReference>
+                </finlex:repeals>
+                <finlex:amendedBy>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2025/437">437/2025</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2026-01-01">1.1.2026</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 24 ja 25 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2026/380">380/2026</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2026-09-01">1.9.2026</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 4, 6, 7 ja 14 §:ää; lis. 36 a §</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2024/29">29/2024</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2025-01-01">1.1.2025</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 8 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2023/1225">1225/2023</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2024-01-01">1.1.2024</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 7 ja 29 § sekä 15, 21 ja 24 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2020/902">902/2020</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2020-12-10">10.12.2020</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>lis. 18 a §</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2020/869">869/2020</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2020-12-01">1.12.2020</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 25 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2023/239">239/2023</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2023-03-01">1.3.2023</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 23 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2022/1112">1112/2022</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2023-06-25">25.6.2023</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>muutt. 14 §:ää</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                </finlex:amendedBy>
+                <finlex:corrigenda>
+                    <finlex:corrigendum href="/akn/fi/act/statute/2018/1050/swe@">
+                        <finlex:datePublished date="2023-01-16">16.1.2023</finlex:datePublished>
+                        <finlex:ref href="corrigenda/fs20181050_1.pdf">1050/2018</finlex:ref>
+                    </finlex:corrigendum>
+                </finlex:corrigenda>
+            </proprietary>
+        </meta>
+        <preface>
+            <p>
+                <docNumber>1050/2018</docNumber>
+                <docTitle>Tietosuojalaki</docTitle>
+            </p>
+        </preface>
+        <preamble>
+            <formula name="enactingClause">
+                <p>Eduskunnan päätöksen mukaisesti säädetään:</p>
+            </formula>
+        </preamble>
+        <body>
+            <hcontainer finlex:outline="Säädöksen teksti" name="statuteProvisionsWrapper">
+                <chapter eId="chp_1">
+                    <num>1 luku</num>
+                    <heading eId="chp_1__heading">Yleiset säännökset</heading>
+                    <section eId="chp_1__sec_1">
+                        <num>1 §</num>
+                        <heading eId="chp_1__sec_1__heading">Lain tarkoitus</heading>
+                        <subsection eId="chp_1__sec_1__subsec_1">
+                            <content>
+                                <p>
+                                    Tällä lailla täsmennetään ja täydennetään luonnollisten henkilöiden suojelusta henkilötietojen käsittelyssä sekä näiden tietojen vapaasta liikkuvuudesta ja direktiivin 95/46/EY kumoamisesta annettua Euroopan parlamentin ja neuvoston asetusta (EU) 2016/679 (yleinen tietosuoja-asetus), jäljempänä 
+                                    <i>tietosuoja-asetus</i>, ja sen kansallista soveltamista.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_1__sec_2">
+                        <num>2 §</num>
+                        <heading eId="chp_1__sec_2__heading">Soveltamisala</heading>
+                        <subsection eId="chp_1__sec_2__subsec_1">
+                            <content>
+                                <p>Tätä lakia sovelletaan tietosuoja-asetuksen 2 artiklan soveltamisalan mukaisesti. Tätä lakia ja tietosuoja-asetusta sovelletaan lisäksi, lukuun ottamatta asetuksen 56 artiklaa ja VII lukua, sellaiseen henkilötietojen käsittelyyn, jota suoritetaan mainitun 2 artiklan 2 kohdan a ja b alakohdassa tarkoitetun toiminnan yhteydessä, jollei muualla laissa toisin säädetä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_2">
+                            <content>
+                                <p>Tätä lakia ei sovelleta eduskunnan valtiopäivätoimintaan.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_3">
+                            <content>
+                                <p>
+                                    Tätä lakia ei sovelleta sellaiseen henkilötietojen käsittelyyn, josta säädetään henkilötietojen käsittelystä rikosasioissa ja kansallisen turvallisuuden ylläpitämisen yhteydessä annetussa laissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/2018/1054">(1054/2018)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_1__sec_3">
+                        <num>3 §</num>
+                        <heading eId="chp_1__sec_3__heading">Sovellettava laki</heading>
+                        <subsection eId="chp_1__sec_3__subsec_1">
+                            <content>
+                                <p>Henkilötietojen käsittelyyn, joka tapahtuu Euroopan unionin alueella sijaitsevaan rekisterinpitäjän tai henkilötietojen käsittelijän toimipaikkaan liittyvän toiminnan yhteydessä, sovelletaan Suomen lakia, jos rekisterinpitäjän toimipaikka sijaitsee Suomessa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_3__subsec_2">
+                            <content>
+                                <p>Jos henkilötietojen käsittelyyn sovelletaan vieraan valtion lakia ja sen nojalla poiketaan tietosuoja-asetuksen 89 artiklan 2 kohdan mukaisesti rekisteröidyn suojaksi säädetyistä oikeuksista, jäljempänä 31 §:ssä rekisteröidyn suojaksi säädettyjä suojatoimia on kuitenkin noudatettava lainvalinnasta riippumatta.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_2">
+                    <num>2 luku</num>
+                    <heading eId="chp_2__heading">Käsittelyn oikeusperuste eräissä tapauksissa</heading>
+                    <section eId="chp_2__sec_4">
+                        <num>4 §</num>
+                        <heading eId="chp_2__sec_4__heading">Käsittelyn lainmukaisuus</heading>
+                        <subsection eId="chp_2__sec_4__subsec_1">
+                            <intro eId="chp_2__sec_4__subsec_1__intro">
+                                <p>Henkilötietoja saa käsitellä tietosuoja-asetuksen 6 artiklan 1 kohdan e alakohdan mukaisesti, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>kysymys on henkilön asemaa, tehtäviä sekä niiden hoitoa julkisyhteisössä, elinkeinoelämässä, järjestötoiminnassa tai muussa vastaavassa toiminnassa kuvaavista tiedoista siltä osin kuin käsittelyn tavoite on yleisen edun mukainen ja käsittely on oikeasuhtaista sillä tavoiteltuun oikeutettuun päämäärään nähden;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_2v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>2)</num>
+                                <content>
+                                    <p>käsittely on tarpeen ja oikeasuhtaista viranomaisen yleistä etua koskevan tehtävän suorittamiseksi tai viranomaiselle kuuluvan julkisen vallan käyttämiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_1" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        L:lla 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                          muutettu 2 kohta tulee voimaan 1.9.2026. Aiempi sanamuoto kuuluu:
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>käsittely on tarpeen ja oikeasuhtaista viranomaisen toiminnassa yleisen edun mukaisen tehtävän suorittamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>käsittely on tarpeen tieteellistä tai historiallista tutkimusta taikka tilastointia varten ja se on oikeasuhtaista sillä tavoiteltuun yleisen edun mukaiseen tavoitteeseen nähden; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>henkilötietoja sisältävien tutkimusaineistojen, kulttuuriperintöaineistojen sekä näiden kuvailutietoihin liittyvien henkilötietojen käsittely arkistointitarkoituksessa on tarpeen ja oikeasuhtaista sillä tavoiteltuun yleisen edun mukaiseen tavoitteeseen ja rekisteröidyn oikeuksiin nähden.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_4__subsec_2v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                            <content>
+                                <p>Mitä 1 momentin 2 kohdassa säädetään, koskee myös yhteisöjä, säätiöitä ja yksityisiä henkilöitä niiden hoitaessa lailla tai lain nojalla annettua julkista hallintotehtävää.</p>
+                            </content>
+                        </subsection>
+                        <hcontainer eId="note_2" finlex:outline="huomautus" name="noteAuthorial">
+                            <content>
+                                <p>
+                                    L:lla 
+                                    <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                     lisätty 2 momentti tulee voimaan 1.9.2026.
+                                </p>
+                            </content>
+                        </hcontainer>
+                    </section>
+                    <section eId="chp_2__sec_5">
+                        <num>5 §</num>
+                        <heading eId="chp_2__sec_5__heading">Tietoyhteiskunnan palvelujen tarjoamiseen lapselle sovellettava ikäraja</heading>
+                        <subsection eId="chp_2__sec_5__subsec_1">
+                            <content>
+                                <p>Kun henkilötietoja käsitellään tietosuoja-asetuksen 6 artiklan 1 kohdan a alakohdassa tarkoitetun suostumuksen perusteella ja kyseessä on tietosuoja-asetuksen 4 artiklan 25 kohdassa tarkoitettujen tietoyhteiskunnan palvelujen tarjoaminen suoraan lapselle, lapsen henkilötietojen käsittely on lainmukaista, jos lapsi on vähintään 13-vuotias.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_6">
+                        <num>6 §</num>
+                        <heading eId="chp_2__sec_6__heading">Erityisiä henkilötietoryhmiä koskeva käsittely</heading>
+                        <subsection eId="chp_2__sec_6__subsec_1">
+                            <intro eId="chp_2__sec_6__subsec_1__intro">
+                                <p>Tietosuoja-asetuksen 9 artiklan 1 kohtaa ei sovelleta:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_1v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>1)</num>
+                                <content>
+                                    <p>vakuutuslaitoksen käsitellessä vakuutustoiminnassa saatuja tietoja vakuutetun, korvauksenhakijan, vakuutuksenhakijan sekä sen henkilön, jolle vakuutussuojaa haetaan, terveydentilasta, sairaudesta tai vammaisuudesta taikka sellaista häneen kohdistetuista hoitotoimenpiteistä tai niihin verrattavista toimista, jotka ovat välttämättömiä vakuutuslaitoksen vastuun arvioimiseksi tai selvittämiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_3" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        L:lla 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                          muutettu 1 kohta tulee voimaan 1.9.2026. Aiempi sanamuoto kuuluu:
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>vakuutuslaitoksen käsitellessä vakuutustoiminnassa saatuja tietoja vakuutetun ja korvauksenhakijan terveydentilasta, sairaudesta tai vammaisuudesta taikka sellaista häneen kohdistetuista hoitotoimenpiteistä tai niihin verrattavista toimista, jotka ovat tarpeen vakuutuslaitoksen vastuun selvittämiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_2v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>2)</num>
+                                <content>
+                                    <p>tietojen käsittelyyn, josta säädetään laissa tai joka on välttämätöntä rekisterinpitäjälle laissa säädetyn yleistä etua koskevan tehtävän suorittamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_4" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        L:lla 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                          muutettu 2 kohta tulee voimaan 1.9.2026. Aiempi sanamuoto kuuluu:
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>tietojen käsittelyyn, josta säädetään laissa tai joka johtuu välittömästi rekisterinpitäjälle laissa säädetystä tehtävästä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>ammattiliittoon kuulumista koskevaan tiedon käsittelyyn, joka on tarpeen rekisterinpitäjän erityisten oikeuksien ja velvoitteiden noudattamiseksi työoikeuden alalla;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>kun terveydenhuollon palveluntarjoaja järjestäessään tai tuottaessaan palveluja käsittelee tässä toiminnassa saamiaan tietoja henkilön terveydentilasta tai vammaisuudesta taikka hänen saamastaan terveydenhuollon ja kuntoutuksen palvelusta taikka muita rekisteröidyn hoidon kannalta välttämättömiä tietoja;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>kun sosiaalihuollon palveluntarjoaja järjestäessään tai tuottaessaan palveluja tai myöntäessään etuuksia käsittelee tässä toiminnassa saamiaan tai tuottamiaan tietoja henkilön terveydentilasta tai vammaisuudesta taikka hänen saamastaan terveydenhuollon ja kuntoutuksen palvelusta taikka muita rekisteröidyn palvelun tai etuuden myöntämisen kannalta välttämättömiä tietoja;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_6">
+                                <num>6)</num>
+                                <content>
+                                    <p>terveyttä koskevien ja geneettisten tietojen käsittelyyn antidopingtyössä ja vammaisurheilun yhteydessä siltä osin kuin näiden tietojen käsittely on välttämätöntä antidopingtyön tai vammaisten ja pitkäaikaissairaiden urheilun mahdollistamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_7">
+                                <num>7)</num>
+                                <content>
+                                    <p>tieteellistä tai historiallista tutkimusta taikka tilastointia varten tehtävään tietojen käsittelyyn;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_8">
+                                <num>8)</num>
+                                <content>
+                                    <p>tutkimus- ja kulttuuriperintöaineistojen käsittelyyn yleishyödyllisessä arkistointitarkoituksessa geneettisiä tietoja lukuun ottamatta.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_6__subsec_2">
+                            <intro eId="chp_2__sec_6__subsec_2__intro">
+                                <p>Käsiteltäessä henkilötietoja 1 momentissa tarkoitetussa tilanteessa rekisterinpitäjän ja henkilötietojen käsittelijän on toteutettava asianmukaiset ja erityiset toimenpiteet rekisteröidyn oikeuksien suojaamiseksi. Näitä toimenpiteitä ovat:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>toimenpiteet, joilla on jälkeenpäin mahdollista varmistaa ja todentaa kenen toimesta henkilötietoja on tallennettu, muutettu tai siirretty;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>toimenpiteet, joilla parannetaan henkilötietoja käsittelevän henkilöstön osaamista;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>tietosuojavastaavan nimittäminen;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>rekisterinpitäjän ja käsittelijän sisäiset toimenpiteet, joilla estetään pääsy henkilötietoihin;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>henkilötietojen pseudonymisointi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_6">
+                                <num>6)</num>
+                                <content>
+                                    <p>henkilötietojen salaaminen;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_7">
+                                <num>7)</num>
+                                <content>
+                                    <p>toimenpiteet, joilla käsittelyjärjestelmien ja henkilötietojen käsittelyyn liittyvien palveluiden jatkuva luottamuksellisuus, eheys, käytettävyys ja vikasietoisuus taataan, mukaan lukien kyky palauttaa nopeasti tietojen saatavuus ja pääsy tietoihin fyysisen tai teknisen vian sattuessa;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_8">
+                                <num>8)</num>
+                                <content>
+                                    <p>menettely, jolla testataan, tutkitaan ja arvioidaan säännöllisesti teknisten ja organisatoristen toimenpiteiden tehokkuutta tietojenkäsittelyn turvallisuuden varmistamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_9">
+                                <num>9)</num>
+                                <content>
+                                    <p>erityiset menettelysäännöt, joilla varmistetaan tietosuoja-asetuksen ja tämän lain noudattaminen siirrettäessä henkilötietoja tai käsiteltäessä henkilötietoja muuhun tarkoitukseen;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_10">
+                                <num>10)</num>
+                                <content>
+                                    <p>tietosuoja-asetuksen 35 artiklan mukainen tietosuojaa koskevan vaikutustenarvioinnin laatiminen;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_11">
+                                <num>11)</num>
+                                <content>
+                                    <p>muut tekniset, menettelylliset ja organisatoriset toimenpiteet.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_6__subsec_3v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                            <content>
+                                <p>Vakuutuslaitoksen on kerättävä 1 momentin 1 kohdassa tarkoitetut tiedot ensi sijassa kohdassa tarkoitetulta henkilöltä itseltään sekä arvioitava tapauskohtaisesti tietojen keräämisen välttämättömyyttä muualta, jollei muualla toisin säädetä. Tiedot on poistettava välittömästi sen jälkeen, kun tietoja ei tarvita vakuutuslaitoksen vastuun arvioimiseksi tai selvittämiseksi, jollei muualla toisin säädetä. Tietoja ei saa käsitellä muuhun kuin mainitussa kohdassa säädettyyn tarkoitukseen, jollei muualla toisin säädetä. Mainitussa kohdassa tarkoitetulle henkilölle on ilmoitettava tietojen käytöstä, jos vakuutushakemuksen epääminen, vakuutuskorvauksen epääminen taikka muu kielteinen päätös johtuu mainitussa kohdassa tarkoitettujen tietojen käsittelystä.</p>
+                            </content>
+                        </subsection>
+                        <hcontainer eId="note_5" finlex:outline="huomautus" name="noteAuthorial">
+                            <content>
+                                <p>
+                                    L:lla 
+                                    <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                     lisätty 3 momentti tulee voimaan 1.9.2026.
+                                </p>
+                            </content>
+                        </hcontainer>
+                    </section>
+                    <section eId="chp_2__sec_7v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                        <num>7 §</num>
+                        <heading eId="chp_2__sec_7v20231225__heading">Rikostuomioihin ja rikoksiin liittyvä käsittely</heading>
+                        <subsection eId="chp_2__sec_7v20231225__subsec_1v20231225">
+                            <intro eId="chp_2__sec_7v20231225__subsec_1v20231225__intro">
+                                <p>Tietosuoja-asetuksen 10 artiklassa tarkoitettuihin rikostuomioihin ja rikoksiin tai niihin liittyviin turvaamistoimiin liittyviä henkilötietoja saa käsitellä, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_1v20231225">
+                                <num>1)</num>
+                                <content>
+                                    <p>käsittely on tarpeen oikeusvaateen selvittämiseksi, laatimiseksi, esittämiseksi, puolustamiseksi tai ratkaisemiseksi; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_2v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>2)</num>
+                                <content>
+                                    <p>käsittely on välttämätöntä vakuutuslaitoksen käsitellessä vakuutustoiminnassa saatuja tietoja vakuutetusta, korvauksenhakijasta, vakuutuksenhakijasta sekä siitä henkilöstä, jolle vakuutussuojaa haetaan vakuutuslaitoksen vastuun arvioimiseksi tai selvittämiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_6" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        L:lla 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                          muutettu 2 kohta tulee voimaan 1.9.2026. Aiempi sanamuoto kuuluu:
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_2v20231225">
+                                <num>2)</num>
+                                <content>
+                                    <p>tietoja käsitellään 6 §:n 1 momentin 1, 2 tai 7 kohdassa säädetyssä tarkoituksessa.</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_3v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>3)</num>
+                                <content>
+                                    <p>käsittelystä säädetään laissa tai käsittely on välttämätöntä välittömästi rekisterinpitäjälle laissa säädetyn yleistä etua koskevan tehtävän suorittamiseksi; tai</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_7" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        L:lla 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                         lisätty 3 kohta tulee voimaan 1.9.2026.
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_4v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>4)</num>
+                                <content>
+                                    <p>käsittely on tarpeen tieteellistä tai historiallista tutkimusta taikka tilastointia varten tehtävään tietojen käsittelyyn.</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_8" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        L:lla 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                         lisätty 4 kohta tulee voimaan 1.9.2026.
+                                    </p>
+                                </content>
+                            </hcontainer>
+                        </subsection>
+                        <subsection eId="chp_2__sec_7v20231225__subsec_2v20231225">
+                            <content>
+                                <p>Mitä 6 §:n 2 momentissa säädetään toimenpiteistä rekisteröidyn oikeuksien suojaamiseksi, sovelletaan myös käsiteltäessä tämän pykälän 1 momentissa tarkoitettuja henkilötietoja.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_2__sec_7v20231225__subsec_3v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                            <content>
+                                <p>Mitä 6 §:n 3 momentissa säädetään toimenpiteistä vakuutetun, korvauksenhakijan, vakuutuksenhakijan sekä sen henkilön, jolle vakuutussuojaa haetaan, oikeuksien suojaamiseksi, sovelletaan myös käsiteltäessä tämän pykälän 1 momentin 2 kohdassa tarkoitettuja henkilötietoja.</p>
+                            </content>
+                        </subsection>
+                        <hcontainer eId="note_9" finlex:outline="huomautus" name="noteAuthorial">
+                            <content>
+                                <p>
+                                    L:lla 
+                                    <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                     lisätty 3 momentti tulee voimaan 1.9.2026.
+                                </p>
+                            </content>
+                        </hcontainer>
+                    </section>
+                </chapter>
+                <chapter eId="chp_3">
+                    <num>3 luku</num>
+                    <heading eId="chp_3__heading">Valvontaviranomainen</heading>
+                    <section eId="chp_3__sec_8">
+                        <num>8 §</num>
+                        <heading eId="chp_3__sec_8__heading">Tietosuojavaltuutettu</heading>
+                        <subsection eId="chp_3__sec_8__subsec_1v20240029" finlex:originalVersion="@20240029" finlex:originalVersionLabel="12.1.2024/29">
+                            <content>
+                                <p>Tietosuoja-asetuksessa tarkoitettuna kansallisena valvontaviranomaisena oikeusministeriön hallinnonalalla on tietosuojavaltuutettu. </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_8__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu on toiminnassaan itsenäinen ja riippumaton.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_9">
+                        <num>9 §</num>
+                        <heading eId="chp_3__sec_9__heading">Tietosuojavaltuutetun toimisto</heading>
+                        <subsection eId="chp_3__sec_9__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetulla on toimisto, jossa on vähintään kaksi apulaistietosuojavaltuutettua sekä tarpeellinen määrä tietosuojavaltuutetun tehtäväalaan perehtyneitä esittelijöitä ja muuta henkilöstöä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_9__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu nimittää toimiston virkamiehet ja ottaa palvelukseen toimiston muun henkilöstön.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_9__subsec_3">
+                            <content>
+                                <p>Tietosuojavaltuutettu hyväksyy toimiston työjärjestyksen.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_10">
+                        <num>10 §</num>
+                        <heading eId="chp_3__sec_10__heading">Kelpoisuusvaatimukset ja nimitysperusteet</heading>
+                        <subsection eId="chp_3__sec_10__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun ja apulaistietosuojavaltuutetun kelpoisuusvaatimuksena on muu oikeustieteen ylempi korkeakoulututkinto kuin kansainvälisen ja vertailevan oikeustieteen maisterin tutkinto, hyvä perehtyneisyys henkilötietojen suojaa koskeviin asioihin sekä käytännössä osoitettu johtamistaito. Lisäksi edellytetään kykyä hoitaa kansainvälisiä tehtäviä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_11">
+                        <num>11 §</num>
+                        <heading eId="chp_3__sec_11__heading">Nimittäminen ja toimikausi</heading>
+                        <subsection eId="chp_3__sec_11__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun ja apulaistietosuojavaltuutetun nimittää valtioneuvosto viideksi vuodeksi kerrallaan.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_11__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutetuksi ja apulaistietosuojavaltuutetuksi nimitetty vapautuu hoitamasta muuta virkaa siksi ajaksi, jona hän toimii tietosuojavaltuutettuna tai apulaistietosuojavaltuutettuna.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_12">
+                        <num>12 §</num>
+                        <heading eId="chp_3__sec_12__heading">Asiantuntijalautakunta</heading>
+                        <subsection eId="chp_3__sec_12__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun toimistossa on asiantuntijalautakunta, johon kuuluu puheenjohtaja, varapuheenjohtaja ja kolme muuta jäsentä. Kullakin heistä on henkilökohtainen varajäsen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_2">
+                            <content>
+                                <p>Valtioneuvosto asettaa lautakunnan kolmen vuoden toimikaudeksi.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_3">
+                            <content>
+                                <p>Lautakunnan puheenjohtajan ja varapuheenjohtajan on oltava oikeustieteen muun ylemmän korkeakoulututkinnon kuin kansainvälisen ja vertailevan oikeustieteen maisterin tutkinnon suorittanut henkilö, jolla on hyvä perehtyneisyys henkilötietojen suojaa koskeviin asioihin ja muu tehtävän hoidon edellyttämä pätevyys. Lautakunnan muulta jäseneltä edellytetään perehtyneisyyttä henkilötietojen suojaa koskeviin asioihin ja tehtävän hoidon edellyttämää muuta pätevyyttä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_4">
+                            <content>
+                                <p>
+                                    Lautakunnan jäseneen sovelletaan rikosoikeudellista virkavastuuta koskevia säännöksiä hänen hoitaessaan tässä laissa tarkoitettuja tehtäviä. Vahingonkorvausvastuusta säädetään vahingonkorvauslaissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/1974/412">(412/1974)</ref>. Lautakunnan jäsenille ja varajäsenille maksetaan tehtävästään palkkio. Oikeusministeriö vahvistaa palkkioiden määrät.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_13">
+                        <num>13 §</num>
+                        <heading eId="chp_3__sec_13__heading">Selvitys sidonnaisuuksista</heading>
+                        <subsection eId="chp_3__sec_13__subsec_1">
+                            <content>
+                                <p>
+                                    Tietosuojavaltuutetun ja apulaistietosuojavaltuutetun on annettava valtion virkamieslain 
+                                    <ref href="/akn/fi/act/statute-consolidated/1994/750#sec_8a">(750/1994) 8 a §:ssä</ref>
+                                     tarkoitettu selvitys sidonnaisuuksistaan.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_14">
+                        <num>14 §</num>
+                        <heading eId="chp_3__sec_14__heading">Tietosuojavaltuutetun tehtävät ja toimivaltuudet</heading>
+                        <subsection eId="chp_3__sec_14__subsec_1v20221112" finlex:originalVersion="@20221112" finlex:originalVersionLabel="20.12.2022/1112">
+                            <content>
+                                <p>
+                                    Tietosuojavaltuutetun tehtävistä ja toimivaltuuksista säädetään tietosuoja-asetuksen 55–59 artiklassa. Tietosuojavaltuutetulla on myös muita tässä tai muussa laissa säädettyjä tehtäviä ja toimivaltuuksia. Tietosuojavaltuutettu voi panna vireille kieltotoimenpiteitä koskevista edustajakanteista annetussa laissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/2022/1101">(1101/2022)</ref>
+                                     tarkoitetun edustajakanteen. 
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu ei valvo valtioneuvoston oikeuskanslerin eikä eduskunnan oikeusasiamiehen toimintaa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_3">
+                            <content>
+                                <p>Tietosuojavaltuutettu edustaa Suomea Euroopan tietosuojaneuvostossa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_4v20260380">
+                            <content>
+                                <p>
+                                    <i>
+                                        4 momentti on kumottu L:lla 
+                                        <ref href="#entryIntoForce_20260380">22.5.2026/380</ref>, joka tulee voimaan 1.9.2026. Aiempi sanamuoto kuuluu:
+                                    </i>
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_4">
+                            <content>
+                                <p>Tietosuojavaltuutettu akkreditoi tietosuoja-asetuksen 43 artiklassa tarkoitetun sertifiointielimen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_5">
+                            <content>
+                                <p>Tietosuojavaltuutettu laatii vuosittain tietosuoja-asetuksen 59 artiklassa tarkoitetun toimintakertomuksen, joka toimitetaan eduskunnalle ja valtioneuvostolle. Toimintakertomus on pidettävä yleisesti saatavilla.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_15">
+                        <num>15 §</num>
+                        <heading eId="chp_3__sec_15__heading">Tietosuojavaltuutetun päätöksenteko</heading>
+                        <subsection eId="chp_3__sec_15__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutettu ratkaisee asiat esittelystä, jollei hän yksittäistapauksessa toisin päätä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_15__subsec_2v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                            <content>
+                                <p>Tietosuojavaltuutettu voi siirtää ratkaisuvaltaa esittelijöinä toimiville virkamiehille työjärjestyksellä tarkemmin määrättävissä asioissa, joissa lain soveltamiskäytäntö on vakiintunut ja joissa asian ratkaiseminen ei asian oikeudellisesta luonteesta tai sisällöstä johtuen edellytä esittelyä tietosuojavaltuutetulle. Tietosuojavaltuutetulla on kuitenkin yksittäistapauksessa oikeus ottaa ratkaistavakseen asia, joka muutoin olisi esittelijän ratkaistava.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_16">
+                        <num>16 §</num>
+                        <heading eId="chp_3__sec_16__heading">Apulaistietosuojavaltuutetun tehtävät ja toimivaltuudet</heading>
+                        <subsection eId="chp_3__sec_16__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetun ja apulaistietosuojavaltuutetun välisestä tehtävien jaosta määrätään tietosuojavaltuutetun toimiston työjärjestyksessä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_16__subsec_2">
+                            <content>
+                                <p>Apulaistietosuojavaltuutetulla on tehtäviensä hoidossa samat toimivaltuudet kuin tietosuojavaltuutetulla.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_17">
+                        <num>17 §</num>
+                        <heading eId="chp_3__sec_17__heading">Asiantuntijalautakunnan tehtävät ja asioiden käsittely</heading>
+                        <subsection eId="chp_3__sec_17__subsec_1">
+                            <content>
+                                <p>Asiantuntijalautakunnan tehtävänä on tietosuojavaltuutetun pyynnöstä antaa lausuntoja henkilötietojen käsittelyä koskevan lainsäädännön soveltamiseen liittyvistä merkittävistä kysymyksistä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_17__subsec_2">
+                            <content>
+                                <p>Lautakunta voi kuulla ulkopuolisia asiantuntijoita.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_17__subsec_3">
+                            <content>
+                                <p>Lautakunnan sihteerinä toimii tietosuojavaltuutetun toimiston esittelijä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_18">
+                        <num>18 §</num>
+                        <heading eId="chp_3__sec_18__heading">Tietosuojavaltuutetun tiedonsaanti- ja tarkastusoikeus</heading>
+                        <subsection eId="chp_3__sec_18__subsec_1">
+                            <content>
+                                <p>Sen lisäksi, mitä tietosuoja-asetuksen 58 artiklan 1 kohdassa säädetään valvontaviranomaisen tiedonsaanti- ja tarkastusoikeudesta, tietosuojavaltuutetulla on oikeus salassapitosäännösten estämättä saada maksutta tehtäviensä hoidon kannalta tarpeelliset tiedot.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_18__subsec_2">
+                            <content>
+                                <p>
+                                    Pysyväisluonteiseen asumiseen käytetyssä tilassa tarkastuksen saa toimittaa vain, jos se on välttämätöntä tarkastuksen kohteena olevien seikkojen selvittämiseksi ja kyseessä olevassa tapauksessa on olemassa perusteltu ja yksilöity syy epäillä henkilötietojen käsittelyä koskevia säännöksiä rikotun tai rikottavan tavalla, josta voi olla seuraamuksena hallinnollinen seuraamusmaksu tai rikoslaissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001">(39/1889)</ref>
+                                     säädetty rangaistus.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_18av20200902" finlex:originalVersion="@20200902" finlex:originalVersionLabel="27.11.2020/902">
+                        <num>18 a §</num>
+                        <heading eId="chp_3__sec_18av20200902__heading">Yhteistyö kolmansien maiden valvontaviranomaisten kanssa</heading>
+                        <subsection eId="chp_3__sec_18av20200902__subsec_1v20200902">
+                            <content>
+                                <p>Sen lisäksi, mitä tietosuoja-asetuksen 61 artiklassa säädetään Euroopan unionin jäsenvaltioiden valvontaviranomaisten keskinäisestä avunannosta, tietosuojavaltuutetulla on oikeus ryhtyä tarvittaviin toimenpiteisiin tehokkaan yhteistyön varmistamiseksi yksilöiden suojelusta henkilötietojen automaattisessa tietojenkäsittelyssä tehdyn yleissopimuksen määräysten noudattamista valvovien viranomaisten kanssa. Tietosuojavaltuutetulla on oikeus luovuttaa salassapitosäännösten estämättä kyseisille valvontaviranomaisille henkilötietoja tai muita tietoja valvontatehtävän suorittamiseksi, jos ne ovat välttämättömiä rekisteröidyn oikeuksien turvaamiseksi tai jos rekisteröity on antanut henkilötietojen luovuttamiseen nimenomaisen suostumuksen.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_19">
+                        <num>19 §</num>
+                        <heading eId="chp_3__sec_19__heading">Asiantuntijoiden käyttö</heading>
+                        <subsection eId="chp_3__sec_19__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutettu voi kuulla ulkopuolisia asiantuntijoita sekä pyytää näiltä lausuntoja.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_19__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu voi käyttää toimivaltaansa kuuluvan tarkastuksen suorittamisessa apunaan ulkopuolisia asiantuntijoita. Asiantuntijaan sovelletaan rikosoikeudellista virkavastuuta koskevia säännöksiä hänen suorittaessaan tällaisia tehtäviä. Vahingonkorvausvastuusta säädetään vahingonkorvauslaissa.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_20">
+                        <num>20 §</num>
+                        <heading eId="chp_3__sec_20__heading">Virka-apu</heading>
+                        <subsection eId="chp_3__sec_20__subsec_1">
+                            <content>
+                                <p>Tietosuojavaltuutetulla on oikeus tehtäviensä suorittamiseksi saada pyynnöstä poliisilta virka-apua.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_4">
+                    <num>4 luku</num>
+                    <heading eId="chp_4__heading">Oikeusturva ja seuraamukset</heading>
+                    <section eId="chp_4__sec_21">
+                        <num>21 §</num>
+                        <heading eId="chp_4__sec_21__heading" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                            Oikeus saattaa asia tietosuojavaltuutetun käsiteltäväksi ja passiivisuusvalitus 
+                            <ref href="#entryIntoForce_20231225">(21.12.2023/1225)</ref>
+                        </heading>
+                        <subsection eId="chp_4__sec_21__subsec_1">
+                            <content>
+                                <p>Rekisteröidyllä on oikeus saattaa asia tietosuojavaltuutetun käsiteltäväksi, jos rekisteröity katsoo, että häntä koskevien henkilötietojen käsittelyssä rikotaan sitä koskevaa lainsäädäntöä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_21__subsec_2">
+                            <content>
+                                <p>Tietosuojavaltuutettu voi keskeyttää asian käsittelyn, jos siihen liittyvä asia on vireillä tuomioistuimessa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_21__subsec_3v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                            <content>
+                                <p>Tietosuojavaltuutetun on käsiteltävä tietosuoja-asetuksen 77 artiklan nojalla vireille tullut kanteluasia kolmen kuukauden kuluessa sen vireilletulosta tai, jos asia ei ole käsiteltävissä tässä ajassa, ilmoitettava rekisteröidylle tässä ajassa arvio päätöksen antamisajankohdasta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_21__subsec_4v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                            <content>
+                                <p>Jos tietosuojavaltuutettu laiminlyö 3 momentissa tarkoitetun kolmen kuukauden määräajan noudattamisen, rekisteröidyllä on oikeus tehdä valitus hallinto-oikeudelle. Valitus on tehtävä ennen kuin tietosuojavaltuutettu on käsitellyt asian tai on antanut arvion päätöksen antamisajankohdasta. Valituksen katsotaan tässä tapauksessa kohdistuvan tutkimatta jättämistä koskevaan päätökseen.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_22">
+                        <num>22 §</num>
+                        <heading eId="chp_4__sec_22__heading">Uhkasakko</heading>
+                        <subsection eId="chp_4__sec_22__subsec_1">
+                            <content>
+                                <p>
+                                    Tietosuojavaltuutettu voi asettaa tietosuoja-asetuksen 58 artiklan 2 kohdan c–g ja j alakohdassa tarkoitetun päätöksen ja tämän lain 18 §:n 1 momenttiin perustuvan tietojen luovuttamista koskevan määräyksen tehosteeksi uhkasakon. Uhkasakon asettamisesta ja tuomitsemisesta maksettavaksi säädetään uhkasakkolaissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/1990/1113">(1113/1990)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_22__subsec_2">
+                            <content>
+                                <p>Uhkasakkoa ei saa asettaa luonnolliselle henkilölle 1 momentissa tarkoitetun tietojen luovuttamista koskevan määräyksen tehosteeksi silloin, kun henkilöä on aihetta epäillä rikoksesta ja tiedot koskevat rikosepäilyn kohteena olevaa asiaa.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_23">
+                        <num>23 §</num>
+                        <heading eId="chp_4__sec_23__heading">Komission päätökset</heading>
+                        <subsection eId="chp_4__sec_23__subsec_1">
+                            <content>
+                                <p>Jos tietosuojavaltuutettu katsoo sillä vireillä olevassa asiassa tarpeelliseksi selvittää, onko tietosuoja-asetuksen 45 artiklassa tarkoitettu Euroopan komission päätös tietosuojan tason riittävyydestä tietosuoja-asetuksen mukainen, tietosuojavaltuutettu voi hakemuksella saattaa ennakkoratkaisun pyytämistä koskevan asian Helsingin hallinto-oikeuden ratkaistavaksi.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_23__subsec_2v20230239">
+                            <content>
+                                <p>
+                                    <i>
+                                        2 momentti on kumottu L:lla 
+                                        <ref href="#entryIntoForce_20230239">16.2.2023/239</ref>.
+                                    </i>
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_24">
+                        <num>24 §</num>
+                        <heading eId="chp_4__sec_24__heading">Hallinnollinen seuraamusmaksu</heading>
+                        <subsection eId="chp_4__sec_24__subsec_1v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                            <content>
+                                <p>Tietosuoja-asetuksen 83 artiklassa säädetyn hallinnollisen seuraamusmaksun määrää tietosuojavaltuutetun ja apulaistietosuojavaltuutettujen yhdessä muodostama seuraamuskollegio. Tietosuojavaltuutettu toimii kollegion puheenjohtajana. Apulaistietosuojavaltuutetun ollessa estynyt voi hänen sijaisenaan seuraamuskollegiossa toimia tietosuojavaltuutetun toimiston työjärjestyksessä määrätty esittelijä. Kollegio on päätösvaltainen kolmijäsenisenä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_2">
+                            <content>
+                                <p>Kollegion päätös tehdään esittelystä. Päätökseksi tulee se kanta, jota enemmistö on kannattanut. Äänten mennessä tasan päätökseksi tulee se kanta, joka on lievempi sille, johon seuraamus kohdistuu.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_3">
+                            <content>
+                                <p>Seuraamusmaksu voidaan määrätä myös tietosuoja-asetuksen 10 artiklan rikkomisesta noudattaen, mitä tietosuoja-asetuksen 83 artiklan 5 kohdassa ja tässä laissa säädetään.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_4">
+                            <content>
+                                <p>Seuraamusmaksua ei voida määrätä valtion viranomaisille, valtion liikelaitoksille, kunnallisille viranomaisille, itsenäisille julkisoikeudellisille laitoksille, eduskunnan virastoille, tasavallan presidentin kanslialle eikä Suomen evankelis-luterilaiselle kirkolle ja Suomen ortodoksiselle kirkolle eikä niiden seurakunnille, seurakuntayhtymille ja muille elimille.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_5">
+                            <content>
+                                <p>Seuraamusmaksua ei saa määrätä, jos on kulunut yli kymmenen vuotta siitä, kun rikkomus tai laiminlyönti on tapahtunut. Jos rikkomus tai laiminlyönti on ollut luonteeltaan jatkuvaa, kymmenen vuoden määräaika lasketaan siitä, kun rikkomus tai laiminlyönti on päättynyt.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_6v20250437" finlex:originalVersion="@20250437" finlex:originalVersionLabel="27.6.2025/437">
+                            <content>
+                                <p>
+                                    Tämän lain nojalla maksettavaksi määrätyn seuraamusmaksun täytäntöönpanosta säädetään sakon täytäntöönpanosta annetussa laissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/2002/672">(672/2002)</ref>. 
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_25">
+                        <num>25 §</num>
+                        <heading eId="chp_4__sec_25__heading">Muutoksenhaku</heading>
+                        <subsection eId="chp_4__sec_25__subsec_1v20200869" finlex:originalVersion="@20200869" finlex:originalVersionLabel="27.11.2020/869">
+                            <content>
+                                <p>
+                                    Muutoksenhausta hallintotuomioistuimeen säädetään oikeudenkäynnistä hallintoasioissa annetussa laissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/2019/808">(808/2019)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_25__subsec_2v20200869">
+                            <content>
+                                <p>
+                                    <i>
+                                        2 momentti on kumottu L:lla 
+                                        <ref href="#entryIntoForce_20200869">27.11.2020/869</ref>.
+                                    </i>
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_25__subsec_3v20250437" finlex:originalVersion="@20250437" finlex:originalVersionLabel="27.6.2025/437">
+                            <content>
+                                <p>Tietosuojavaltuutetun tai apulaistietosuojavaltuutetun päätöksessä voidaan määrätä, että päätöstä on noudatettava muutoksenhausta huolimatta, jollei valitusviranomainen toisin määrää. Uhkasakon ja seuraamusmaksun täytäntöönpanokelpoisuudesta säädetään sakon täytäntöönpanosta annetussa laissa.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_26">
+                        <num>26 §</num>
+                        <heading eId="chp_4__sec_26__heading">Rangaistussäännökset</heading>
+                        <subsection eId="chp_4__sec_26__subsec_1">
+                            <content>
+                                <p>
+                                    Rangaistus tietosuojarikoksesta säädetään 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001#chp_38__sec_9">rikoslain 38 luvun 9 §:ssä</ref>. Rangaistus viestintäsalaisuuden loukkauksesta ja törkeästä viestintäsalaisuuden loukkauksesta säädetään 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001#chp_38">rikoslain 38 luvun</ref>
+                                     3 ja 4 §:ssä sekä rangaistus tietomurrosta ja törkeästä tietomurrosta 38 luvun 8 ja 8 a §:ssä. Rangaistus tämän lain 35 §:ssä säädetyn vaitiolovelvollisuuden ja 36 §:ssä säädetyn salassapitovelvollisuuden rikkomisesta tuomitaan 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001#chp_38">rikoslain 38 luvun</ref>
+                                     1 tai 2 §:n mukaan, jollei teko ole rangaistava 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001#chp_40__sec_5">rikoslain 40 luvun 5 §:n</ref>
+                                     mukaan tai siitä muualla laissa säädetä ankarampaa rangaistusta.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_26__subsec_2">
+                            <content>
+                                <p>Rikoslain 38 luvun 10 §:n 3 momentissa säädetään syyttäjän velvollisuudesta kuulla tietosuojavaltuutettua ennen tämän pykälän 1 momentissa mainittuja rikoksia koskevan syytteen nostamista samoin kuin tuomioistuimen velvollisuudesta varata tällaista asiaa käsitellessään tietosuojavaltuutetulle tilaisuus tulla kuulluksi.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_5">
+                    <num>5 luku</num>
+                    <heading eId="chp_5__heading">Tietojenkäsittelyn erityistilanteet</heading>
+                    <section eId="chp_5__sec_27">
+                        <num>27 §</num>
+                        <heading eId="chp_5__sec_27__heading">Henkilötietojen käsittely journalistisen, akateemisen, taiteellisen tai kirjallisen ilmaisun tarkoituksia varten</heading>
+                        <subsection eId="chp_5__sec_27__subsec_1">
+                            <content>
+                                <p>Sananvapauden ja tiedonvälityksen vapauden turvaamiseksi henkilötietojen käsittelyyn ainoastaan journalistisia tarkoituksia varten tai akateemisen, taiteellisen tai kirjallisen ilmaisun tarkoituksia varten ei sovelleta tietosuoja-asetuksen 5 artiklan 1 kohdan c–e alakohtaa, 6 ja 7 artiklaa, 9 ja 10 artiklaa, 11 artiklan 2 kohtaa, 12–22 artiklaa, 30 artiklaa, 34 artiklan 1–3 kohtaa, 35 ja 36 artiklaa, 56 artiklaa, 58 artiklan 2 kohdan f alakohtaa, 60–63 artiklaa ja 65–67 artiklaa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_27__subsec_2">
+                            <content>
+                                <p>
+                                    Tietosuoja-asetuksen 27 artiklaa ei sovelleta sellaiseen henkilötietojen käsittelyyn, joka liittyy sananvapauden käyttämisestä joukkoviestinnässä annetussa laissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/2003/460">(460/2003)</ref>
+                                     säädettyyn toimintaan. Tietosuoja-asetuksen 44–50 artiklaa ei sovelleta, jos soveltaminen loukkaisi oikeutta sananvapauteen tai tiedonvälityksen vapauteen.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_27__subsec_3">
+                            <content>
+                                <p>Sananvapauden ja tiedonvälityksen vapauden turvaamiseksi henkilötietojen käsittelyyn ainoastaan journalistisia tarkoituksia varten tai akateemisen, taiteellisen tai kirjallisen ilmaisun tarkoituksia varten sovelletaan tietosuoja-asetuksen 5 artiklan 1 kohdan a ja b alakohtaa ja 2 kohtaa, 24–26 artiklaa, 31 artiklaa, 39 ja 40 artiklaa, 42 artiklaa, 57 ja 58 artiklaa, 64 artiklaa ja 70 artiklaa ainoastaan soveltuvin osin.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_28">
+                        <num>28 §</num>
+                        <heading eId="chp_5__sec_28__heading">Julkisuusperiaate</heading>
+                        <subsection eId="chp_5__sec_28__subsec_1">
+                            <content>
+                                <p>Oikeuteen saada tieto ja muuhun henkilötietojen luovuttamiseen viranomaisen henkilörekisteristä sovelletaan, mitä viranomaisten toiminnan julkisuudesta säädetään.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_29v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                        <num>29 §</num>
+                        <heading eId="chp_5__sec_29v20231225__heading">Henkilötunnuksen käsittely</heading>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_1v20231225">
+                            <intro eId="chp_5__sec_29v20231225__subsec_1v20231225__intro">
+                                <p>
+                                    Henkilötunnusta saa käsitellä rekisteröidyn suostumuksella tai, jos käsittelystä säädetään laissa. Lisäksi henkilötunnusta saa käsitellä, jos rekisteröidyn ja hänen henkilötietojensa yksiselitteinen erottaminen muista rekisteröidyistä ja heidän henkilötiedoistaan (<i>yksilöiminen</i>) on tärkeää:
+                                </p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_29v20231225__subsec_1v20231225__para_1v20231225">
+                                <num>1)</num>
+                                <content>
+                                    <p>laissa säädetyn tehtävän suorittamiseksi;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_29v20231225__subsec_1v20231225__para_2v20231225">
+                                <num>2)</num>
+                                <content>
+                                    <p>rekisteröidyn tai rekisterinpitäjän oikeuksien ja velvollisuuksien toteuttamiseksi; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_29v20231225__subsec_1v20231225__para_3v20231225">
+                                <num>3)</num>
+                                <content>
+                                    <p>historiallista tai tieteellistä tutkimusta taikka tilastointia varten.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_2v20231225">
+                            <content>
+                                <p>Henkilötunnusta saa käsitellä rekisteröidyn yksiselitteiseksi yksilöimiseksi luotonannossa ja saatavan perimisessä, vakuutus-, luottolaitos-, maksupalvelu-, vuokraus- ja lainaustoiminnassa, luottotietotoiminnassa, terveydenhuollossa, sosiaalihuollossa ja muun sosiaaliturvan toteuttamisessa sekä virka-, työ- ja muita palvelussuhteita ja niihin liittyviä etuja koskevissa asioissa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_3v20231225">
+                            <content>
+                                <p>Sen lisäksi, mitä henkilötunnuksen käsittelystä 1 ja 2 momentissa säädetään, henkilötunnuksen saa luovuttaa osoitetietojen päivittämiseksi tai moninkertaisten postilähetysten välttämiseksi suoritettavaa tietojenkäsittelyä varten, jos henkilötunnus jo on luovutuksensaajan käytettävissä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_4v20231225">
+                            <content>
+                                <p>Henkilötunnusta ei tule tarpeettomasti merkitä rekisterin perusteella tulostettuihin tai laadittuihin asiakirjoihin.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_5v20231225">
+                            <content>
+                                <p>
+                                    Rekisteröidyn henkilöllisyyden selvittämiseen hänen ilmoittamiensa tai toimittamiensa tietojen taikka esittämiensä asiakirjojen avulla (<i>tunnistaminen</i>) ei saa käyttää yksinomaan henkilötunnusta tai henkilötunnuksen ja rekisteröidyn nimen yhdistelmää.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_30">
+                        <num>30 §</num>
+                        <heading eId="chp_5__sec_30__heading">Henkilötietojen käsittely työsuhteen yhteydessä</heading>
+                        <subsection eId="chp_5__sec_30__subsec_1">
+                            <content>
+                                <p>
+                                    Työntekijää koskevien henkilötietojen käsittelystä, työntekijälle tehtävistä testeistä ja tarkastuksista sekä niitä koskevista vaatimuksista, teknisestä valvonnasta työpaikalla sekä työntekijän sähköpostiviestin hakemisesta ja avaamisesta säädetään yksityisyyden suojasta työelämässä annetussa laissa 
+                                    <ref href="/akn/fi/act/statute-consolidated/2004/759">(759/2004)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_31">
+                        <num>31 §</num>
+                        <heading eId="chp_5__sec_31__heading">Tieteellisiä ja historiallisia tutkimustarkoituksia sekä tilastollisia tarkoituksia varten tapahtuvaa henkilötietojen käsittelyä koskevat poikkeukset ja suojatoimet</heading>
+                        <subsection eId="chp_5__sec_31__subsec_1">
+                            <intro eId="chp_5__sec_31__subsec_1__intro">
+                                <p>Käsiteltäessä henkilötietoja tieteellistä tai historiallista tutkimustarkoitusta varten voidaan tietosuoja-asetuksen 15, 16, 18 ja 21 artiklassa säädetyistä rekisteröidyn oikeuksista tarvittaessa poiketa edellyttäen, että:</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_31__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>käsittely perustuu asianmukaiseen tutkimussuunnitelmaan;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>tutkimuksella on vastuuhenkilö tai siitä vastaava ryhmä; ja</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>henkilötietoja käytetään ja luovutetaan vain historiallista tai tieteellistä tutkimusta taikka muuta yhteensopivaa tarkoitusta varten sekä muutoinkin toimitaan niin, että tiettyä henkilöä koskevat tiedot eivät paljastu ulkopuolisille.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_31__subsec_2">
+                            <intro eId="chp_5__sec_31__subsec_2__intro">
+                                <p>Käsiteltäessä henkilötietoja tilastollisia tarkoituksia varten voidaan tietosuoja-asetuksen 15, 16, 18 ja 21 artiklassa säädetyistä rekisteröidyn oikeuksista tarvittaessa poiketa edellyttäen, että:</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_31__subsec_2__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>tilastoa ei voida tuottaa tai sen tarkoituksena olevaa tiedontarvetta toteuttaa ilman henkilötietojen käsittelyä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_2__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>kyseisen tilaston tuottamisella on asiallinen yhteys rekisterinpitäjän toimintaan; ja</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_2__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>tietoja ei luovuteta tai aseteta saataville siten, että tietty henkilö on niistä tunnistettavissa, ellei tietoja luovuteta julkista tilastoa varten.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_31__subsec_3">
+                            <content>
+                                <p>Käsiteltäessä tietosuoja-asetuksen 9 artiklan 1 kohdassa ja 10 artiklassa tarkoitettuja henkilötietoja 1 tai 2 momentissa säädetyssä tarkoituksessa poikkeaminen tietosuoja-asetuksen 15, 16, 18 ja 21 artiklassa säädetyistä rekisteröidyn oikeuksista edellyttää sen lisäksi, mitä 1 ja 2 momentissa säädetään, että laaditaan tietosuoja-asetuksen 35 artiklan mukainen tietosuojaa koskeva vaikutustenarviointi tai noudatetaan tietosuoja-asetuksen 40 artiklan mukaisia käytännesääntöjä, joissa on otettu asianmukaisesti huomioon edellä tarkoitettu rekisteröidyn oikeuksista poikkeaminen. Vaikutustenarviointi tulee toimittaa kirjallisesti tiedoksi tietosuojavaltuutetulle ennen käsittelyyn ryhtymistä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_32">
+                        <num>32 §</num>
+                        <heading eId="chp_5__sec_32__heading">Yleisen edun mukaisia arkistointitarkoituksia varten tapahtuvaa henkilötietojen käsittelyä koskevat poikkeukset ja suojatoimet</heading>
+                        <subsection eId="chp_5__sec_32__subsec_1">
+                            <content>
+                                <p>Käsiteltäessä henkilötietoja yleisen edun mukaisia arkistointitarkoituksia varten 4 §:n 4 kohdan tai tietosuoja-asetuksen 6 artiklan 1 kohdan c alakohdan nojalla voidaan tietosuoja-asetuksen 15, 16 ja 18–21 artiklassa tarkoitetuista rekisteröidyn oikeuksista poiketa tietosuoja-asetuksen 89 artiklan 3 kohdassa säädetyin edellytyksin.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_33">
+                        <num>33 §</num>
+                        <heading eId="chp_5__sec_33__heading">Rajoitukset rekisterinpitäjän velvollisuuteen toimittaa tietoja rekisteröidylle</heading>
+                        <subsection eId="chp_5__sec_33__subsec_1">
+                            <content>
+                                <p>Tietosuoja-asetuksen 13 ja 14 artiklan mukaisesta velvollisuudesta toimittaa tiedot rekisteröidylle voidaan poiketa, jos se on välttämätöntä valtion turvallisuuden, puolustuksen tai yleisen järjestyksen ja turvallisuuden vuoksi, rikosten ehkäisemiseksi tai selvittämiseksi taikka verotukseen tai julkiseen talouteen liittyvän valvontatehtävän vuoksi.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_33__subsec_2">
+                            <content>
+                                <p>Tietosuoja-asetuksen 14 artiklan 1–4 kohdasta voidaan poiketa myös, jos tiedon toimittaminen aiheuttaa olennaista vahinkoa tai haittaa rekisteröidylle eikä talletettavia tietoja käytetä rekisteröityä koskevaan päätöksentekoon.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_33__subsec_3">
+                            <content>
+                                <p>Jos rekisteröidylle ei toimiteta 1 tai 2 momentin perusteella tietoa, rekisterinpitäjän on toteutettava asianmukaiset toimenpiteet rekisteröidyn oikeuksien suojaamiseksi. Näihin toimenpiteisiin kuuluu tietosuoja-asetuksen 14 artiklan 1 ja 2 kohdassa tarkoitettujen tietojen pitäminen kaikkien saatavilla, ellei tämä vaaranna tietojen toimittamista koskevan rajoituksen tarkoitusta.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_34">
+                        <num>34 §</num>
+                        <heading eId="chp_5__sec_34__heading">Rajoitukset rekisteröidyn oikeuteen tutustua hänestä kerättyihin tietoihin</heading>
+                        <subsection eId="chp_5__sec_34__subsec_1">
+                            <intro eId="chp_5__sec_34__subsec_1__intro">
+                                <p>Rekisteröidyllä ei ole tietosuoja-asetuksen 15 artiklassa tarkoitettua oikeutta tutustua hänestä kerättyihin tietoihin, jos:</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_34__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>tiedon antaminen saattaisi vahingoittaa kansallista turvallisuutta, puolustusta tai yleistä järjestystä ja turvallisuutta taikka haitata rikosten ehkäisemistä tai selvittämistä;</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_34__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>tiedon antamisesta saattaisi aiheutua vakavaa vaaraa rekisteröidyn terveydelle tai hoidolle taikka rekisteröidyn tai jonkun muun oikeuksille; tai</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_34__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>henkilötietoja käytetään valvonta- ja tarkastustehtävissä ja tiedon antamatta jättäminen on välttämätöntä Suomen tai Euroopan unionin tärkeän taloudellisen tai rahoituksellisen edun turvaamiseksi.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_34__subsec_2">
+                            <content>
+                                <p>Jos vain osa rekisteröityä koskevista tiedoista on sellaisia, että ne 1 momentin mukaan jäävät tietosuoja-asetuksen 15 artiklassa tarkoitetun oikeuden ulkopuolelle, rekisteröidyllä on oikeus saada tietää muut häntä koskevat tiedot.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_34__subsec_3">
+                            <content>
+                                <p>Rekisteröidylle on ilmoitettava rajoituksen syyt, ellei tämä vaaranna rajoituksen tarkoitusta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_34__subsec_4">
+                            <content>
+                                <p>Jos rekisteröidyllä ei ole oikeutta tutustua hänestä kerättyihin tietoihin, tietosuoja-asetuksen 15 artiklan 1 kohdassa tarkoitetut tiedot on annettava tietosuojavaltuutetulle rekisteröidyn pyynnöstä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_6">
+                    <num>6 luku</num>
+                    <heading eId="chp_6__heading">Erinäiset säännökset</heading>
+                    <section eId="chp_6__sec_35">
+                        <num>35 §</num>
+                        <heading eId="chp_6__sec_35__heading">Vaitiolovelvollisuus</heading>
+                        <subsection eId="chp_6__sec_35__subsec_1">
+                            <content>
+                                <p>Joka henkilötietojen käsittelyyn liittyviä toimenpiteitä suorittaessaan on saanut tietää jotakin toisen henkilön ominaisuuksista, henkilökohtaisista oloista, taloudellisesta asemasta taikka toisen liikesalaisuudesta, ei saa oikeudettomasti ilmaista sivulliselle näin saamiaan tietoja eikä käyttää niitä omaksi tai toisen hyödyksi tai toisen vahingoksi.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_36">
+                        <num>36 §</num>
+                        <heading eId="chp_6__sec_36__heading">Ilmoittajan henkilöllisyyden suojaaminen</heading>
+                        <subsection eId="chp_6__sec_36__subsec_1">
+                            <content>
+                                <p>Kun luonnollinen henkilö on tehnyt tietosuojavaltuutetulle ilmoituksen sen valvontaan kuuluvien säännösten epäillystä rikkomisesta, ilmoittajan henkilöllisyys on pidettävä salassa, jos henkilöllisyyden paljastamisesta voidaan olosuhteiden perusteella arvioida aiheutuvan haittaa ilmoittajalle.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_36av20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                        <num>36 a §</num>
+                        <heading eId="chp_6__sec_36av20260380__heading">Sertifiointielimen akkreditointi</heading>
+                        <subsection eId="chp_6__sec_36av20260380__subsec_1v20260380">
+                            <content>
+                                <p>Kansallinen akkreditointielin akkreditoi tietosuoja-asetuksen 43 artiklassa tarkoitetun sertifiointielimen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_36av20260380__subsec_2v20260380">
+                            <content>
+                                <p>Akkreditoinnissa teknisenä asiantuntijana toimii ensisijaisesti tietosuojavaltuutettu ja toissijaisesti kansallisen akkreditointielimen nimeämä asiantuntija. Jos teknisenä asiantuntijana toimii kansallisen akkreditointielimen nimeämä asiantuntija, tietosuojavaltuutetulle on ennen akkreditoinnin myöntämistä varattava tilaisuus lausua tietosuoja-asetuksen 43 artiklan 2 ja 3 kohdassa tarkoitettujen, tietosuojaa koskevien edellytysten täyttymisestä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_36av20260380__subsec_3v20260380">
+                            <content>
+                                <p>Kansallinen akkreditointielin määrää ja perii valtiolle maksun tämän pykälän nojalla toteutetuista akkreditointi- ja arviointipalveluista. Tietosuojavaltuutetun toimistolla on oikeus saada kansalliselta akkreditointielimeltä korvaus tämän pykälän mukaisten tehtävien suorittamisesta.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <hcontainer eId="note_10" finlex:outline="huomautus" name="noteAuthorial">
+                        <content>
+                            <p>
+                                L:lla 
+                                <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>
+                                 lisätty 36 a § tulee voimaan 1.9.2026.
+                            </p>
+                        </content>
+                    </hcontainer>
+                    <section eId="chp_6__sec_37" finlex:entryIntoForce="true" finlex:vsId="1050/2018">
+                        <num>37 §</num>
+                        <heading eId="chp_6__sec_37__heading">Voimaantulo</heading>
+                        <subsection eId="chp_6__sec_37__subsec_1">
+                            <content>
+                                <p>Tämä laki tulee voimaan 1 päivänä tammikuuta 2019.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_37__subsec_2">
+                            <content>
+                                <p>
+                                    Tällä lailla kumotaan henkilötietolaki 
+                                    <ref href="/akn/fi/act/statute-consolidated/1999/523">(523/1999)</ref>
+                                     sekä tietosuojalautakunnasta ja tietosuojavaltuutetusta annettu laki 
+                                    <ref href="/akn/fi/act/statute-consolidated/1994/389">(389/1994)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_38" finlex:entryIntoForce="true" finlex:vsId="1050/2018">
+                        <num>38 §</num>
+                        <heading eId="chp_6__sec_38__heading">Siirtymäsäännökset</heading>
+                        <subsection eId="chp_6__sec_38__subsec_1">
+                            <content>
+                                <p>Tietosuojalautakunnan myöntämien lupien voimassaolo päättyy tämän lain tullessa voimaan. Tietosuojalautakunnassa ennen tämän lain voimaantuloa vireille tulleet asiat raukeavat lain voimaan tullessa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_2">
+                            <content>
+                                <p>Tämän lain voimaan tullessa vireillä olevaan tietosuojavaltuutetulle tehtävää ilmoitusta koskevaan asiaan sovelletaan henkilötietolain 36 ja 37 §:n säännöksiä ilmoitusvelvollisuudesta ja ilmoituksen tekemisestä.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_3">
+                            <content>
+                                <p>Tämän lain voimaan tullessa vireillä olevassa tarkastusoikeuden toteuttamista ja henkilötietojen korjaamista koskevassa asiassa ei sovelleta sellaisia tietosuoja-asetuksen 12 ja 15–18 artiklan säännöksiä, joissa asetetaan rekisterinpitäjälle laajempia velvollisuuksia kuin tämän lain voimaan tullessa voimassa olleet säännökset edellyttävät, jos mainittujen tietosuoja-asetuksen säännösten soveltaminen olisi rekisterinpitäjän kannalta kohtuutonta.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_4">
+                            <content>
+                                <p>Haettaessa muutosta ennen tämän lain voimaantuloa tehtyyn tietosuojalautakunnan ja tietosuojavaltuutetun päätökseen sovelletaan tämän lain voimaan tullessa voimassa olleita säännöksiä. Ylimääräiseen muutoksenhakuun sovelletaan tämän lain voimaan tullessa voimassa olleita säännöksiä kuitenkin vain, jos se on pantu vireille ennen tämän lain voimaantuloa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_5">
+                            <content>
+                                <p>Jos vahinkoa aiheuttanut teko on tehty ennen tämän lain voimaantuloa, velvollisuuteen korvata vahinko sovelletaan tämän lain voimaan tullessa voimassa olleita säännöksiä.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+            </hcontainer>
+            <hcontainer finlex:outline="Esityöt ja allekirjoitukset" name="conclusions">
+                <hcontainer finlex:outline="Esityöt" name="preliminaryWork">
+                    <content>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2018/9">HE 9/2018</ref>
+                        </p>
+                        <p>HaVM 13/2018</p>
+                        <p>EV 108/2018</p>
+                        <p>Euroopan parlamentin ja neuvoston asetus (EU) N:o 679/2016 (32016R0679); EUVL L 119, 4.5.2016, s. 1</p>
+                    </content>
+                </hcontainer>
+            </hcontainer>
+            <hcontainer name="amendmentEntryIntoForceAndApplianceProvisions">
+                <heading>Muutossäädösten voimaantulo ja soveltaminen</heading>
+                <hcontainer eId="entryIntoForce_20200869" name="entryIntoForce">
+                    <heading>27.11.2020/869:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä joulukuuta 2020.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2020/109">HE 109/2020</ref>, LaVM 10/2020, EV 136/2020
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20200902" name="entryIntoForce">
+                    <heading>27.11.2020/902:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 10 päivänä joulukuuta 2020.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2020/30">HE 30/2020</ref>, HaVM 16/2020, EV 125/2020
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20221112" name="entryIntoForce">
+                    <heading>20.12.2022/1112:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 25 päivänä kesäkuuta 2023.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2022/111">HE 111/2022</ref>, LaVM 20/2022, EV 204/2022, Euroopan parlamentin ja neuvoston direktiivi (EU) 2020/1828  (32020L1828); EUVL L 409, 4.12.2020, s.1
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20230239" name="entryIntoForce">
+                    <heading>16.2.2023/239:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä maaliskuuta 2023.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2022/93">HE 93/2022</ref>, LaVM 25/2022, EV 252/2022
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20231225" name="entryIntoForce">
+                    <heading>21.12.2023/1225:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä tammikuuta 2024.</p>
+                        <p>Tämän lain 21 §:n 3 ja 4 momenttia ei sovelleta lain voimaan tullessa tietosuojavaltuutetun käsiteltävinä oleviin asioihin. </p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2023/62">HE 62/2023</ref>, HaVM 9/2023, EV 55/2023
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20240029" name="entryIntoForce">
+                    <heading>12.1.2024/29:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä tammikuuta 2025.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2023/31">HE 31/2023</ref>, LaVM 6/2023, EV 47/2023
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20250437" name="entryIntoForce">
+                    <heading>27.6.2025/437:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä tammikuuta 2026.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2025/5">HE 5/2025</ref>, LaVM 6/2025, EV 52/2025
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20260380" name="entryIntoForce">
+                    <heading>22.5.2026/380:</heading>
+                    <content>
+                        <p>Tämä laki tulee voimaan 1 päivänä syyskuuta 2026.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2026/9">HE 9/2026</ref>, HaVM 4/2026, EV 46/2026
+                        </p>
+                    </content>
+                </hcontainer>
+            </hcontainer>
+        </body>
+    </act>
+</akomaNtoso>

--- a/tests/fixtures/finlex/statute-consolidated-2018-1050-swe-latest.xml
+++ b/tests/fixtures/finlex/statute-consolidated-2018-1050-swe-latest.xml
@@ -1,0 +1,1308 @@
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:finlex="http://data.finlex.fi/schema/finlex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <act contains="multipleVersions" name="main">
+        <meta>
+            <identification source="#organization_fi.finlex">
+                <FRBRWork>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/2018/1050/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/2018/1050"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/ajantasa"/>
+                    <FRBRdate date="2018-12-05" name="dateIssued"/>
+                    <FRBRdate date="2018-12-10" name="datePublished"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.finlex"/>
+                    <FRBRcountry value="fi"/>
+                    <FRBRsubtype value="statute-consolidated"/>
+                    <FRBRnumber value="1050"/>
+                    <FRBRprescriptive value="false"/>
+                    <FRBRauthoritative value="false"/>
+                </FRBRWork>
+                <FRBRExpression>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/2018/1050/swe@20260380/!main"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/2018/1050/swe@20260380"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/ajantasa/2026-05-22/swe"/>
+                    <FRBRdate date="2018-12-05" name="dateIssued"/>
+                    <FRBRdate date="2026-05-22" name="dateConsolidated"/>
+                    <FRBRauthor as="#role_author" href="#organization_fi.finlex"/>
+                    <FRBRversionNumber value="20260380"/>
+                    <FRBRlanguage language="swe"/>
+                </FRBRExpression>
+                <FRBRManifestation>
+                    <FRBRthis value="/akn/fi/act/statute-consolidated/2018/1050/swe@20260380/!main.xml"/>
+                    <FRBRuri value="/akn/fi/act/statute-consolidated/2018/1050/swe@20260380.akn"/>
+                    <FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/ajantasa/2026-05-22/swe/xml"/>
+                    <FRBRdate date="2026-06-01" name="dateProduced"/>
+                    <FRBRdate date="2018-12-10" name="datePublished"/>
+                    <FRBRauthor as="#role_editor" href="#organization_fi.finlex"/>
+                    <FRBRformat value="xml"/>
+                </FRBRManifestation>
+            </identification>
+            <classification source="#organization_fi.finlex">
+                <keyword dictionary="/akn/ontology/concept/statute-keyword" showAs="Dataskydd" value="/akn/ontology/concept/statute-keyword.3876"/>
+            </classification>
+            <references source="#organization_fi.finlex">
+                <TLCOrganization eId="organization_fi.finlex" href="/akn/ontology/organization/fi.finlex" showAs="Finlex"/>
+                <TLCRole eId="role_author" href="/akn/ontology/role/author" showAs="Tekijä"/>
+                <TLCRole eId="role_editor" href="/akn/ontology/role/editor" showAs="Toimittaja"/>
+                <TLCOrganization eId="fi.ministry-of-justice" href="/akn/ontology/organization/fi.ministry-of-justice" showAs="Justitieministeriet"/>
+                <TLCConcept eId="act" href="/akn/ontology/concept/statute/type-statute.act" showAs="Lag"/>
+            </references>
+            <proprietary source="#organization_fi.finlex">
+                <finlex:documentYear>2018</finlex:documentYear>
+                <finlex:administrativeBranch refersTo="#fi.ministry-of-justice"/>
+                <finlex:typeStatute refersTo="#act"/>
+                <finlex:isInForce value="true"/>
+                <finlex:inForce>
+                    <finlex:dateEntryIntoForce date="2019-01-01"/>
+                </finlex:inForce>
+                <finlex:repeals>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute-consolidated/1994/389">389/1994</finlex:ref>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute-consolidated/1999/523">523/1999</finlex:ref>
+                    </finlex:statuteReference>
+                </finlex:repeals>
+                <finlex:amendedBy>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2025/437">437/2025</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2026-01-01">1.1.2026</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>ändrar 24 och 25 § delvis</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2026/380">380/2026</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2026-09-01">1.9.2026</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>ändrar 4, 6, 7 och 14 § delvis; fogas till 36 a §</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2024/29">29/2024</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2025-01-01">1.1.2025</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>ändrar 8 § delvis</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2023/1225">1225/2023</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2024-01-01">1.1.2024</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>ändrar 7 och 29 § och även 15, 21 och 24 § delvis</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2020/902">902/2020</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2020-12-10">10.12.2020</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>fogas till 18 a §</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2020/869">869/2020</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2020-12-01">1.12.2020</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>ändrar 25 § delvis</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2023/239">239/2023</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2023-03-01">1.3.2023</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>ändrar 23 § delvis</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                    <finlex:statuteReference>
+                        <finlex:ref href="/akn/fi/act/statute/2022/1112">1112/2022</finlex:ref>
+                        <finlex:inForce>
+                            <finlex:dateEntryIntoForce date="2023-06-25">25.6.2023</finlex:dateEntryIntoForce>
+                        </finlex:inForce>
+                        <finlex:noteEditorial>ändrar 14 § delvis</finlex:noteEditorial>
+                    </finlex:statuteReference>
+                </finlex:amendedBy>
+                <finlex:corrigenda>
+                    <finlex:corrigendum href="/akn/fi/act/statute/2018/1050/swe@">
+                        <finlex:datePublished date="2023-01-16">16.1.2023</finlex:datePublished>
+                        <finlex:ref href="corrigenda/fs20181050_1.pdf">1050/2018</finlex:ref>
+                    </finlex:corrigendum>
+                </finlex:corrigenda>
+            </proprietary>
+        </meta>
+        <preface>
+            <p>
+                <docNumber>1050/2018</docNumber>
+                <docTitle>Dataskyddslag</docTitle>
+            </p>
+        </preface>
+        <preamble>
+            <formula name="enactingClause">
+                <p>I enlighet med riksdagens beslut föreskrivs:</p>
+            </formula>
+        </preamble>
+        <body>
+            <hcontainer finlex:outline="Förordningens text" name="statuteProvisionsWrapper">
+                <chapter eId="chp_1">
+                    <num>1 kap.</num>
+                    <heading eId="chp_1__heading">Allmänna bestämmelser</heading>
+                    <section eId="chp_1__sec_1">
+                        <num>1 §</num>
+                        <heading eId="chp_1__sec_1__heading">Lagens syfte</heading>
+                        <subsection eId="chp_1__sec_1__subsec_1">
+                            <content>
+                                <p>
+                                    Genom denna lag preciseras och kompletteras Europaparlamentets och rådets förordning (EU) 2016/679 om skydd för fysiska personer med avseende på behandling av personuppgifter och om det fria flödet av sådana uppgifter och om upphävande av direktiv 95/46/EG (allmän dataskyddsförordning), nedan 
+                                    <i>dataskyddsförordningen</i>, och dess nationella tillämpning.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_1__sec_2">
+                        <num>2 §</num>
+                        <heading eId="chp_1__sec_2__heading">Tillämpningsområde</heading>
+                        <subsection eId="chp_1__sec_2__subsec_1">
+                            <content>
+                                <p>Denna lag tillämpas i enlighet med tillämpningsområdet i artikel 2 i dataskyddsförordningen. Denna lag och dataskyddsförordningen tillämpas dessutom, med undantag för artikel 56 och kapitel VII i förordningen, på sådan behandling av personuppgifter som utförs i samband med verksamhet som avses i artikel 2.2 a och b i dataskyddsförordningen, om inte något annat föreskrivs någon annanstans i lag.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_2">
+                            <content>
+                                <p>Denna lag tillämpas inte på riksdagsarbetet.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_2__subsec_3">
+                            <content>
+                                <p>
+                                    Denna lag tillämpas inte på sådan behandling av personuppgifter som regleras i lagen om behandling av personuppgifter i brottmål och vid upprätthållandet av den nationella säkerheten 
+                                    <ref href="/akn/fi/act/statute-consolidated/2018/1054">(1054/2018)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_1__sec_3">
+                        <num>3 §</num>
+                        <heading eId="chp_1__sec_3__heading">Tillämplig lag</heading>
+                        <subsection eId="chp_1__sec_3__subsec_1">
+                            <content>
+                                <p>På sådan behandling av personuppgifter som sker inom ramen för verksamhet vid en personuppgiftsansvarigs eller ett personuppgiftsbiträdes verksamhetsställe i Europeiska unionen ska finsk lag tillämpas, om den personuppgiftsansvariges verksamhetsställe finns i Finland.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_1__sec_3__subsec_2">
+                            <content>
+                                <p>Om en främmande stats lag ska tillämpas på behandling av personuppgifter och det med stöd av den lagen görs ett undantag i enlighet med artikel 89.2 i dataskyddsförordningen från de rättigheter som föreskrivs för att skydda registrerade, ska de skyddsåtgärder till skydd för registrerade som anges i 31 § dock iakttas oberoende av lagvalet.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_2">
+                    <num>2 kap.</num>
+                    <heading eId="chp_2__heading">Rättslig grund för behandling av personuppgifter i vissa fall</heading>
+                    <section eId="chp_2__sec_4">
+                        <num>4 §</num>
+                        <heading eId="chp_2__sec_4__heading">Laglig behandling av personuppgifter</heading>
+                        <subsection eId="chp_2__sec_4__subsec_1">
+                            <intro eId="chp_2__sec_4__subsec_1__intro">
+                                <p>Personuppgifter får behandlas i enlighet med artikel 6.1 e i dataskyddsförordningen, om</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>det är fråga om uppgifter som beskriver en persons ställning samt uppdrag och skötseln av detta inom ett offentligt samfund, näringslivet, organisationsverksamhet eller någon annan motsvarande verksamhet, i den mån som syftet med behandlingen är förenligt med allmänt intresse och behandlingen står i proportion till det legitima mål som eftersträvas,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_2v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>2)</num>
+                                <content>
+                                    <p>behandlingen behövs och är proportionell för utförandet av en myndighets uppgift av allmänt intresse eller som ett led i myndighetens utövning av offentlig makt,</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_1" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        2 punkten har ändrats genom L 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026. Den tidigare formen lyder:
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>behandlingen behövs och är proportionell i en myndighets verksamhet för utförande av en uppgift av allmänt intresse,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>behandlingen behövs för vetenskaplig eller historisk forskning eller för statistikföring och den står i proportion till det mål av allmänt intresse som eftersträvas, eller</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_4__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>behandling av forskningsmaterial och kulturarvsmaterial som innehåller personuppgifter samt av personuppgifter som hänför sig till innehålls- och referensinformation som gäller sådant material behövs för arkivändamål och behandlingen står i proportion till det mål av allmänt intresse som eftersträvas och den registrerades rättigheter.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_4__subsec_2v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                            <content>
+                                <p>Vad som föreskrivs i 1 mom. 2 punkten gäller också sammanslutningar, stiftelser och enskilda personer när de sköter offentliga förvaltningsuppgifter som har anförtrotts dem genom lag eller med stöd av lag.</p>
+                            </content>
+                        </subsection>
+                        <hcontainer eId="note_2" finlex:outline="huomautus" name="noteAuthorial">
+                            <content>
+                                <p>
+                                    2 mom. har tillfogats genom L 
+                                    <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026.
+                                </p>
+                            </content>
+                        </hcontainer>
+                    </section>
+                    <section eId="chp_2__sec_5">
+                        <num>5 §</num>
+                        <heading eId="chp_2__sec_5__heading">Åldersgräns som tillämpas när informationssamhällets tjänster erbjuds till barn</heading>
+                        <subsection eId="chp_2__sec_5__subsec_1">
+                            <content>
+                                <p>När personuppgifter behandlas med samtycke enligt artikel 6.1 a i dataskyddsförordningen och det är fråga om informationssamhällets tjänster enligt artikel 4.25 i dataskyddsförordningen som erbjuds direkt till ett barn, är behandlingen av barnets personuppgifter lagenlig, om barnet är minst 13 år.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_2__sec_6">
+                        <num>6 §</num>
+                        <heading eId="chp_2__sec_6__heading">Behandling av särskilda kategorier av personuppgifter</heading>
+                        <subsection eId="chp_2__sec_6__subsec_1">
+                            <intro eId="chp_2__sec_6__subsec_1__intro">
+                                <p>Artikel 9.1 i dataskyddsförordningen tillämpas inte</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_1v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>1)</num>
+                                <content>
+                                    <p>när en försäkringsanstalt behandlar uppgifter som anstalten i försäkringsverksamheten fått om hälsotillståndet, sjukdom eller funktionsnedsättning hos en försäkrad, en ersättningssökande, en försäkringssökande eller den som försäkringsskydd söks för, eller sådana uppgifter om de vårdåtgärder eller andra därmed jämförbara åtgärder som avser personen i fråga och som är nödvändiga för att bedöma eller utreda anstaltens ansvar,</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_3" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        1 punkten har ändrats genom L 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026. Den tidigare formen lyder:
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>när en försäkringsanstalt behandlar uppgifter som anstalten i försäkringsverksamheten fått om en försäkrads eller ersättningssökandes hälsotillstånd, sjukdom eller funktionsnedsättning eller sådana uppgifter om de vårdåtgärder eller andra därmed jämförbara åtgärder som avser den försäkrade och som behövs för att utreda anstaltens ansvar,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_2v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>2)</num>
+                                <content>
+                                    <p>på sådan behandling av uppgifter som regleras i lag eller som är nödvändig för utförandet av en uppgift av allmänt intresse som har ålagts den personuppgiftsansvarige i lag,</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_4" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        2 punkten har ändrats genom L 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026. Den tidigare formen lyder:
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>på sådan behandling av uppgifter som regleras i lag eller som föranleds av en uppgift som direkt har ålagts den personuppgiftsansvarige i lag,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>på sådan behandling av uppgifter om medlemskap i fackförbund som behövs för att den personuppgiftsansvarige ska kunna iaktta sina särskilda rättigheter och skyldigheter inom arbetsrättens område,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>när en tillhandahållare av hälso- och sjukvårdstjänster vid ordnande eller produktion av tjänster behandlar uppgifter som tillhandahållaren i denna verksamhet fått om en persons hälsotillstånd eller funktionsnedsättning eller om en hälso- och sjukvårdstjänst och rehabiliteringstjänst som personen fått eller andra uppgifter som är nödvändiga med avseende på den registrerades vård,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>när en tillhandahållare av socialvårdstjänster vid ordnande eller produktion av tjänster eller beviljande av förmåner behandlar uppgifter som tillhandahållaren i denna verksamhet fått eller producerat om en persons hälsotillstånd eller funktionsnedsättning eller om en hälso- och sjukvårdstjänst och rehabiliteringstjänst som personen fått eller andra uppgifter som är nödvändiga med avseende på beviljande av tjänster och förmåner till den registrerade,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_6">
+                                <num>6)</num>
+                                <content>
+                                    <p>på behandling av hälsouppgifter och genetiska uppgifter i antidopningsarbete och i samband med idrott för personer med funktionsnedsättning, i den mån behandlingen av dessa uppgifter är nödvändig för att möjliggöra antidopningsarbetet eller idrott för personer med funktionsnedsättning och idrott för långtidssjuka,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_7">
+                                <num>7)</num>
+                                <content>
+                                    <p>på behandling av uppgifter för vetenskaplig eller historisk forskning eller för statistikföring,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_1__para_8">
+                                <num>8)</num>
+                                <content>
+                                    <p>på behandling av forskningsmaterial och kulturarvsmaterial för allmännyttiga arkivändamål, med undantag för genetiska uppgifter.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_6__subsec_2">
+                            <intro eId="chp_2__sec_6__subsec_2__intro">
+                                <p>En personuppgiftsansvarig och ett personuppgiftsbiträde som behandlar personuppgifter i en situation som avses i 1 mom. ska vidta lämpliga och särskilda åtgärder för att skydda den registrerades rättigheter. Sådana åtgärder är</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>åtgärder för att det i efterhand ska kunna säkerställas och bevisas vem som har registrerat, ändrat eller överfört personuppgifter,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>åtgärder för att höja kompetensen hos den personal som behandlar personuppgifter,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>utnämning av ett dataskyddsombud,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_4">
+                                <num>4)</num>
+                                <content>
+                                    <p>den personuppgiftsansvariges och personuppgiftsbiträdets interna åtgärder för att förhindra tillträde till personuppgifter,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_5">
+                                <num>5)</num>
+                                <content>
+                                    <p>pseudonymisering av personuppgifter,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_6">
+                                <num>6)</num>
+                                <content>
+                                    <p>kryptering av personuppgifter,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_7">
+                                <num>7)</num>
+                                <content>
+                                    <p>åtgärder för att fortlöpande säkerställa konfidentialitet, integritet, tillgänglighet och motståndskraft hos behandlingssystemen och tjänsterna i anknytning till behandlingen av personuppgifterna, inbegripet förmåga att återställa tillgängligheten och tillgången till uppgifterna i rimlig tid vid en fysisk eller teknisk incident,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_8">
+                                <num>8)</num>
+                                <content>
+                                    <p>ett förfarande för att regelbundet testa, undersöka och utvärdera effektiviteten hos de tekniska och organisatoriska åtgärder som ska säkerställa behandlingens säkerhet,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_9">
+                                <num>9)</num>
+                                <content>
+                                    <p>särskilda förfaranderegler för att säkerställa att dataskyddsförordningen och denna lag iakttas när personuppgifter överförs eller behandlas för något annat ändamål,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_10">
+                                <num>10)</num>
+                                <content>
+                                    <p>utförande av en konsekvensbedömning avseende dataskydd enligt artikel 35 i dataskyddsförordningen.</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_6__subsec_2__para_11">
+                                <num>11)</num>
+                                <content>
+                                    <p>andra tekniska, förfarandemässiga och organisatoriska åtgärder.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_2__sec_6__subsec_3v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                            <content>
+                                <p>Försäkringsanstalten ska i första hand samla in de uppgifter som avses i 1 mom. 1 punkten av personen själv när det gäller personer som avses i den punkten och från fall till fall bedöma huruvida det är nödvändigt att samla in dessa uppgifter från annat håll, om inte annat föreskrivs någon annanstans. Uppgifterna ska utplånas omedelbart efter att de inte längre behövs för bedömning eller utredning av försäkringsanstaltens ansvar, om inte annat föreskrivs någon annanstans. Uppgifterna får inte behandlas för något annat ändamål än det som avses i den punkten, om inte annat föreskrivs någon annanstans. En person som avses i den punkten ska informeras om användningen av uppgifterna, om avslag på en försäkringsansökan, förvägran av försäkringsersättning eller ett annat negativt beslut beror på behandlingen av de uppgifter som avses i den punkten.</p>
+                            </content>
+                        </subsection>
+                        <hcontainer eId="note_5" finlex:outline="huomautus" name="noteAuthorial">
+                            <content>
+                                <p>
+                                    3 mom. har tillfogats genom L 
+                                    <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026.
+                                </p>
+                            </content>
+                        </hcontainer>
+                    </section>
+                    <section eId="chp_2__sec_7v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                        <num>7 §</num>
+                        <heading eId="chp_2__sec_7v20231225__heading">Behandling av personuppgifter som rör fällande domar i brottmål samt lagöverträdelser som innefattar brott</heading>
+                        <subsection eId="chp_2__sec_7v20231225__subsec_1v20231225">
+                            <intro eId="chp_2__sec_7v20231225__subsec_1v20231225__intro">
+                                <p>Personuppgifter som rör i artikel 10 i dataskyddsförordningen avsedda fällande domar i brottmål och lagöverträdelser som innefattar brott eller därmed sammanhängande säkerhetsåtgärder får behandlas om</p>
+                            </intro>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_1v20231225">
+                                <num>1)</num>
+                                <content>
+                                    <p>behandlingen behövs för utredning, fastställande, utövande, försvar eller avgörande av rättsliga anspråk, eller</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_2v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>2)</num>
+                                <content>
+                                    <p>behandlingen är nödvändig när en försäkringsanstalt behandlar uppgifter som anstalten i försäkringsverksamheten fått om en försäkrad, en ersättningssökande, en försäkringssökande eller den som försäkringsskydd söks för i syfte att bedöma eller utreda anstaltens ansvar,</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_6" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        2 punkten har ändrats genom L 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026. Den tidigare formen lyder:
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_2v20231225">
+                                <num>2)</num>
+                                <content>
+                                    <p>uppgifterna behandlas för syften som anges i 6 § 1 mom. 1, 2 eller 7 punkten.</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_3v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>3)</num>
+                                <content>
+                                    <p>behandlingen regleras i lag eller är nödvändig för utförandet av en uppgift av allmänt intresse som direkt har ålagts den personuppgiftsansvarige i lag, eller</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_7" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        3 punkten har tillfogats genom L 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026.
+                                    </p>
+                                </content>
+                            </hcontainer>
+                            <paragraph eId="chp_2__sec_7v20231225__subsec_1v20231225__para_4v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                                <num>4)</num>
+                                <content>
+                                    <p>behandlingen behövs för behandling av uppgifter för vetenskaplig eller historisk forskning eller för statistikföring.</p>
+                                </content>
+                            </paragraph>
+                            <hcontainer eId="note_8" finlex:outline="huomautus" name="noteAuthorial">
+                                <content>
+                                    <p>
+                                        4 punkten har tillfogats genom L 
+                                        <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026.
+                                    </p>
+                                </content>
+                            </hcontainer>
+                        </subsection>
+                        <subsection eId="chp_2__sec_7v20231225__subsec_2v20231225">
+                            <content>
+                                <p>Vad som i 6 § 2 mom. föreskrivs om åtgärder för att skydda den registrerades rättigheter tillämpas även vid behandling av sådana personuppgifter som avses i 1 mom. i denna paragraf.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_2__sec_7v20231225__subsec_3v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                            <content>
+                                <p>Vad som i 6 § 3 mom. föreskrivs om åtgärder för att skydda rättigheterna för en försäkrad, en ersättningssökande, en försäkringssökande eller den som försäkringsskydd söks för tillämpas även vid behandling av sådana personuppgifter som avses i 1 mom. 2 punkten i denna paragraf.</p>
+                            </content>
+                        </subsection>
+                        <hcontainer eId="note_9" finlex:outline="huomautus" name="noteAuthorial">
+                            <content>
+                                <p>
+                                    3 mom. har tillfogats genom L 
+                                    <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026.
+                                </p>
+                            </content>
+                        </hcontainer>
+                    </section>
+                </chapter>
+                <chapter eId="chp_3">
+                    <num>3 kap.</num>
+                    <heading eId="chp_3__heading">Tillsynsmyndighet</heading>
+                    <section eId="chp_3__sec_8">
+                        <num>8 §</num>
+                        <heading eId="chp_3__sec_8__heading">Dataombudsmannen</heading>
+                        <subsection eId="chp_3__sec_8__subsec_1v20240029" finlex:originalVersion="@20240029" finlex:originalVersionLabel="12.1.2024/29">
+                            <content>
+                                <p>Dataombudsmannen är den nationella tillsynsmyndighet som avses i dataskyddsförordningen. Dataombudsmannen finns inom justitieministeriets förvaltningsområde.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_8__subsec_2">
+                            <content>
+                                <p>Dataombudsmannen är självständig och oberoende i sin verksamhet.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_9">
+                        <num>9 §</num>
+                        <heading eId="chp_3__sec_9__heading">Dataombudsmannens byrå</heading>
+                        <subsection eId="chp_3__sec_9__subsec_1">
+                            <content>
+                                <p>Dataombudsmannen har en byrå med minst två biträdande dataombudsmän och ett behövligt antal föredragande som är förtrogna med dataombudsmannens uppgiftsområde och annan personal.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_9__subsec_2">
+                            <content>
+                                <p>Dataombudsmannen utnämner tjänstemännen och anställer den övriga personalen vid byrån.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_9__subsec_3">
+                            <content>
+                                <p>Dataombudsmannen godkänner en arbetsordning för byrån.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_10">
+                        <num>10 §</num>
+                        <heading eId="chp_3__sec_10__heading">Behörighetsvillkor och utnämningsgrunder</heading>
+                        <subsection eId="chp_3__sec_10__subsec_1">
+                            <content>
+                                <p>Behörighetsvillkor för dataombudsmannen och biträdande dataombudsmän är annan högre högskoleexamen i juridik än magisterexamen i internationell och komparativ rätt, god förtrogenhet med frågor som gäller skydd av personuppgifter och i praktiken visad ledarförmåga. Dessutom förutsätts förmåga att sköta internationella uppgifter.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_11">
+                        <num>11 §</num>
+                        <heading eId="chp_3__sec_11__heading">Utnämning och mandatperiod</heading>
+                        <subsection eId="chp_3__sec_11__subsec_1">
+                            <content>
+                                <p>Dataombudsmannen och biträdande dataombudsmän utnämns av statsrådet för fem år i sänder.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_11__subsec_2">
+                            <content>
+                                <p>Den som utnämns till dataombudsman och biträdande dataombudsman är fri från skötseln av en annan tjänst under den tid som han eller hon är dataombudsman eller biträdande dataombudsman.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_12">
+                        <num>12 §</num>
+                        <heading eId="chp_3__sec_12__heading">Sakkunnignämnd</heading>
+                        <subsection eId="chp_3__sec_12__subsec_1">
+                            <content>
+                                <p>Vid dataombudsmannens byrå finns en sakkunnignämnd som består av ordförande, en vice ordförande och tre andra ledamöter. Var och en av dem ska ha en personlig ersättare.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_2">
+                            <content>
+                                <p>Statsrådet tillsätter nämnden för en mandatperiod på tre år.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_3">
+                            <content>
+                                <p>Nämndens ordförande och vice ordförande ska ha avlagt annan högre högskoleexamen i juridik än magisterexamen i internationell och komparativ rätt och ha god förtrogenhet med frågor som gäller skydd av personuppgifter och den övriga kompetens som skötseln av uppgiften förutsätter. Av nämndens övriga ledamöter förutsätts förtrogenhet med frågor som gäller skydd av personuppgifter och den övriga kompetens som skötseln av uppgiften förutsätter.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_12__subsec_4">
+                            <content>
+                                <p>
+                                    På nämndens ledamöter tillämpas bestämmelserna om straffrättsligt tjänsteansvar när de sköter uppgifter som avses i denna lag. Bestämmelser om skadeståndsansvar finns i skadeståndslagen 
+                                    <ref href="/akn/fi/act/statute-consolidated/1974/412">(412/1974)</ref>. Nämndens ledamöter och ersättarna betalas arvode för uppdraget. Justitieministeriet fastställer arvodesbeloppen.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_13">
+                        <num>13 §</num>
+                        <heading eId="chp_3__sec_13__heading">Redogörelse för bindningar</heading>
+                        <subsection eId="chp_3__sec_13__subsec_1">
+                            <content>
+                                <p>
+                                    Dataombudsmannen och biträdande dataombudsmän ska lämna en i 8 a § i statstjänstemannalagen 
+                                    <ref href="/akn/fi/act/statute-consolidated/1994/750">(750/1994)</ref>
+                                     avsedd redogörelse för sina bindningar.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_14">
+                        <num>14 §</num>
+                        <heading eId="chp_3__sec_14__heading">Dataombudsmannens uppgifter och befogenheter</heading>
+                        <subsection eId="chp_3__sec_14__subsec_1v20221112" finlex:originalVersion="@20221112" finlex:originalVersionLabel="20.12.2022/1112">
+                            <content>
+                                <p>
+                                    Bestämmelser om dataombudsmannens uppgifter och befogenheter finns i artiklarna 55–59 i dataskyddsförordningen. Dataombudsmannen har också andra uppgifter och befogenheter som anges i denna lag och annanstans i lag. Dataombudsmannen får väcka sådan grupptalan som avses i lagen om grupptalan om åtgärder för förbudsföreläggande 
+                                    <ref href="/akn/fi/act/statute-consolidated/2022/1101">(1101/2022)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_2">
+                            <content>
+                                <p>Dataombudsmannen övervakar inte statsrådets justitiekanslers eller riksdagens justitieombudsmans verksamhet.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_3">
+                            <content>
+                                <p>Dataombudsmannen företräder Finland i Europeiska dataskyddsstyrelsen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_4v20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                            <content>
+                                <p>
+                                    4 mom. har upphävts genom L 
+                                    <ref href="#entryIntoForce_20260380">22.5.2026/380</ref>, som träder i kraft 1.9.2026. Den tidigare formen lyder:
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_4">
+                            <content>
+                                <p>Dataombudsmannen ackrediterar det certifieringsorgan som avses i artikel 43 i dataskyddsförordningen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_14__subsec_5">
+                            <content>
+                                <p>Dataombudsmannen ska upprätta en årlig rapport om sin verksamhet enligt artikel 59 i dataskyddsförordningen och lämna den till riksdagen och statsrådet. Verksamhetsrapporten ska hållas allmänt tillgänglig.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_15">
+                        <num>15 §</num>
+                        <heading eId="chp_3__sec_15__heading">Dataombudsmannens beslutsfattande</heading>
+                        <subsection eId="chp_3__sec_15__subsec_1">
+                            <content>
+                                <p>Dataombudsmannen avgör ärenden efter föredragning, om inte han eller hon i ett enskilt fall beslutar något annat.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_15__subsec_2v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                            <content>
+                                <p>I ärenden om vilka det bestäms närmare i arbetsordningen och i vilka praxis i fråga om lagens tillämpning är vedertagen och avgörandet av ärendet inte förutsätter föredragning för dataombudsmannen på grund av ärendets rättsliga natur eller innehåll får dataombudsmannen överföra beslutanderätten på tjänstemän som är föredragande. Dataombudsmannen har dock i enskilda fall rätt att överta avgörandet av ett ärende som annars skulle avgöras av en föredragande.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_16">
+                        <num>16 §</num>
+                        <heading eId="chp_3__sec_16__heading">Biträdande dataombudsmannens uppgifter och befogenheter</heading>
+                        <subsection eId="chp_3__sec_16__subsec_1">
+                            <content>
+                                <p>Uppgiftsfördelningen mellan dataombudsmannen och de biträdande dataombudsmännen bestäms i arbetsordningen för dataombudsmannens byrå.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_16__subsec_2">
+                            <content>
+                                <p>En biträdande dataombudsman har vid skötseln av sina uppgifter samma befogenheter som dataombudsmannen.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_17">
+                        <num>17 §</num>
+                        <heading eId="chp_3__sec_17__heading">Sakkunnignämndens uppgifter och behandling av ärenden</heading>
+                        <subsection eId="chp_3__sec_17__subsec_1">
+                            <content>
+                                <p>Sakkunnignämnden ska på dataombudsmannens begäran ge utlåtanden om viktiga frågor i samband med tillämpningen av lagstiftning som gäller behandling av personuppgifter.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_17__subsec_2">
+                            <content>
+                                <p>Nämnden kan höra utomstående sakkunniga.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_17__subsec_3">
+                            <content>
+                                <p>En föredragande vid dataombudsmannens byrå är sekreterare för nämnden.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_18">
+                        <num>18 §</num>
+                        <heading eId="chp_3__sec_18__heading">Dataombudsmannens rätt att få information och utföra inspektioner</heading>
+                        <subsection eId="chp_3__sec_18__subsec_1">
+                            <content>
+                                <p>Dataombudsmannen har, utöver vad som i artikel 58.1 i dataskyddsförordningen föreskrivs om tillsynsmyndighetens rätt att få information och utföra inspektioner, rätt att trots sekretessbestämmelserna avgiftsfritt få de uppgifter som behövs för skötseln av sina uppgifter.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_18__subsec_2">
+                            <content>
+                                <p>
+                                    I utrymmen som används för boende av permanent natur får inspektion utföras endast om det är nödvändigt för att utreda de omständigheter som är föremål för inspektion och det i det aktuella fallet finns motiverade och specificerade skäl att misstänka att det har skett eller kommer att ske en sådan överträdelse av bestämmelserna om behandling av personuppgifter att påföljden kan vara en administrativ påföljdsavgift eller ett straff enligt strafflagen 
+                                    <ref href="/akn/fi/act/statute-consolidated/1889/39-001">(39/1889)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_18av20200902" finlex:originalVersion="@20200902" finlex:originalVersionLabel="27.11.2020/902">
+                        <num>18 a §</num>
+                        <heading eId="chp_3__sec_18av20200902__heading">Samarbete med tillsynsmyndigheter i tredjeländer</heading>
+                        <subsection eId="chp_3__sec_18av20200902__subsec_1v20200902">
+                            <content>
+                                <p>Dataombudsmannen har, utöver vad som i artikel 61 i dataskyddsförordningen föreskrivs om ömsesidigt bistånd mellan tillsynsmyndigheterna i Europeiska unionens medlemsstater, rätt att vidta behövliga åtgärder för att säkerställa ett effektivt samarbete med de tillsynsmyndigheter som kontrollerar att bestämmelserna i konventionen om skydd för enskilda vid automatisk databehandling av personuppgifter följs. Dataombudsmannen har trots sekretessbestämmelserna rätt att till dessa tillsynsmyndigheter lämna ut personuppgifter och andra uppgifter för utförande av tillsynsuppdrag, om uppgifterna är nödvändiga för att trygga den registrerades rättigheter eller om den registrerade har gett sitt uttryckliga samtycke till att personuppgifterna lämnas ut.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_19">
+                        <num>19 §</num>
+                        <heading eId="chp_3__sec_19__heading">Anlitande av sakkunniga</heading>
+                        <subsection eId="chp_3__sec_19__subsec_1">
+                            <content>
+                                <p>Dataombudsmannen får höra utomstående sakkunniga och begära utlåtanden från dem.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_3__sec_19__subsec_2">
+                            <content>
+                                <p>Dataombudsmannen får vid inspektioner som ingår i dataombudsmannens befogenheter anlita biträde av utomstående sakkunniga. På en sakkunnig tillämpas bestämmelserna om straffrättsligt tjänsteansvar när han eller hon sköter sådana uppgifter. Bestämmelser om skadeståndsansvar finns i skadeståndslagen.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_3__sec_20">
+                        <num>20 §</num>
+                        <heading eId="chp_3__sec_20__heading">Handräckning</heading>
+                        <subsection eId="chp_3__sec_20__subsec_1">
+                            <content>
+                                <p>Dataombudsmannen har rätt att på begäran få handräckning av polisen för att utföra sina uppgifter.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_4">
+                    <num>4 kap.</num>
+                    <heading eId="chp_4__heading">Rättssäkerhet och påföljder</heading>
+                    <section eId="chp_4__sec_21">
+                        <num>21 §</num>
+                        <heading eId="chp_4__sec_21__heading" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                            Rätt att föra ärenden till dataombudsmannen för behandling samt passivitetsbesvär 
+                            <ref href="#entryIntoForce_20231225">(21.12.2023/1225)</ref>
+                        </heading>
+                        <subsection eId="chp_4__sec_21__subsec_1">
+                            <content>
+                                <p>En registrerad har rätt att föra ett ärende till dataombudsmannen för behandling, om den registrerade anser att någon vid behandlingen av hans eller hennes personuppgifter bryter mot den gällande lagstiftningen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_21__subsec_2">
+                            <content>
+                                <p>Dataombudsmannen kan avbryta behandlingen av ett ärende, om ett ärende som har samband med det är anhängigt i domstol.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_21__subsec_3v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                            <content>
+                                <p>Dataombudsmannen ska behandla ett klagomål som blivit anhängigt med stöd av artikel 77 i dataskyddsförordningen inom tre månader från det att klagomålet blev anhängigt eller, om ärendet inte kan behandlas inom denna tid, inom tre månader meddela den registrerade en uppskattning om när ett beslut kommer att ges.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_21__subsec_4v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                            <content>
+                                <p>Om dataombudsmannen försummar att iaktta den tidsfrist på tre månader som avses i 3 mom., har den registrerade rätt att anföra besvär hos förvaltningsdomstolen. Besvären ska anföras innan dataombudsmannen har behandlat ärendet eller meddelat en uppskattning om när ett beslut kommer att ges. Besvären anses då avse ett beslut att avvisa ärendet.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_22">
+                        <num>22 §</num>
+                        <heading eId="chp_4__sec_22__heading">Vite</heading>
+                        <subsection eId="chp_4__sec_22__subsec_1">
+                            <content>
+                                <p>
+                                    Dataombudsmannen får förena ett i dataskyddsförordningens artikel 58.2 c–g och j avsett beslut samt ett med stöd av 18 § 1 mom. i denna lag meddelat föreläggande att lämna ut uppgifter med vite. Bestämmelser om föreläggande och utdömande av vite finns i viteslagen 
+                                    <ref href="/akn/fi/act/statute-consolidated/1990/1113">(1113/1990)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_22__subsec_2">
+                            <content>
+                                <p>Ett i 1 mom. avsett föreläggande att lämna ut uppgifter får inte förenas med ett vitesföreläggande riktat till en fysisk person, om det finns anledning att misstänka personen för brott och uppgifterna gäller en omständighet som har samband med brottsmisstanken.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_23">
+                        <num>23 §</num>
+                        <heading eId="chp_4__sec_23__heading">Beslut av kommissionen</heading>
+                        <subsection eId="chp_4__sec_23__subsec_1">
+                            <content>
+                                <p>Om dataombudsmannen i ett ärende som är anhängigt hos dataombudsmannen anser att det behöver utredas om ett beslut som Europeiska kommissionen fattat om adekvat skyddsnivå enligt artikel 45 i dataskyddsförordningen är förenligt med dataskyddsförordningen, kan dataombudsmannen genom en ansökan föra ett ärende som gäller begäran om förhandsavgörande till Helsingfors förvaltningsdomstol för avgörande.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_23__subsec_2v20230239" finlex:originalVersion="@20230239" finlex:originalVersionLabel="16.2.2023/239">
+                            <content>
+                                <p>
+                                    2 mom. har upphävts genom L 
+                                    <ref href="#entryIntoForce_20230239">16.2.2023/239</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_24">
+                        <num>24 §</num>
+                        <heading eId="chp_4__sec_24__heading">Administrativa påföljdsavgifter</heading>
+                        <subsection eId="chp_4__sec_24__subsec_1">
+                            <content>
+                                <p>
+                                    Administrativa sanktionsavgifter (<i>administrativa påföljdsavgifter</i>) enligt artikel 83 i dataskyddsförordningen påförs av ett påföljdskollegium som består av dataombudsmannen och de biträdande dataombudsmännen tillsammans. Dataombudsmannen är ordförande för kollegiet. Om en biträdande dataombudsman har förhinder, kan denne ersättas i påföljdskollegiet av en föredragande som utses för detta i arbetsordningen för dataombudsmannens byrå. Kollegiet är beslutfört med tre medlemmar.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_2">
+                            <content>
+                                <p>Kollegiet ska fatta beslut efter föredragning. Som beslut gäller den mening som flertalet har understött. Vid lika röstetal gäller som beslut den mening som är lindrigare för den som påföljden riktas mot.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_3">
+                            <content>
+                                <p>Påföljdsavgifter får påföras även för överträdelse av artikel 10 i dataskyddsförordningen, med iakttagande av vad som föreskrivs i artikel 83.5 i dataskyddsförordningen och i denna lag.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_4">
+                            <content>
+                                <p>Statliga myndigheter, statliga affärsverk, kommunala myndigheter, självständiga offentligrättsliga institutioner, riksdagens ämbetsverk, republikens presidents kansli, evangelisk-lutherska kyrkan i Finland, ortodoxa kyrkan i Finland och de två sistnämndas församlingar, kyrkliga samfälligheter och övriga organ får inte påföras påföljdsavgift.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_5">
+                            <content>
+                                <p>Påföljdsavgift får inte påföras, om det har förflutit mer än tio år sedan överträdelsen eller försummelsen har skett. Om överträdelsen eller försummelsen har varit fortlöpande räknas den tioåriga tidsfristen från det att överträdelsen eller försummelsen har upphört.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_24__subsec_6v20250437" finlex:originalVersion="@20250437" finlex:originalVersionLabel="27.6.2025/437">
+                            <content>
+                                <p>
+                                    Bestämmelser om verkställigheten av påföljdsavgift som påförts med stöd av denna lag finns i lagen om verkställighet av böter 
+                                    <ref href="/akn/fi/act/statute-consolidated/2002/672">(672/2002)</ref>. 
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_25">
+                        <num>25 §</num>
+                        <heading eId="chp_4__sec_25__heading">Ändringssökande</heading>
+                        <subsection eId="chp_4__sec_25__subsec_1v20200869" finlex:originalVersion="@20200869" finlex:originalVersionLabel="27.11.2020/869">
+                            <content>
+                                <p>
+                                    Bestämmelser om sökande av ändring i förvaltningsdomstol finns i lagen om rättegång i förvaltningsärenden 
+                                    <ref href="/akn/fi/act/statute-consolidated/2019/808">(808/2019)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_25__subsec_2v20200869" finlex:originalVersion="@20200869" finlex:originalVersionLabel="27.11.2020/869">
+                            <content>
+                                <p>
+                                    2 mom. har upphävts genom L 
+                                    <ref href="#entryIntoForce_20200869">27.11.2020/869</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_25__subsec_3v20250437" finlex:originalVersion="@20250437" finlex:originalVersionLabel="27.6.2025/437">
+                            <content>
+                                <p>I ett beslut av dataombudsmannen eller en biträdande dataombudsman kan det bestämmas att beslutet ska iakttas trots ändringssökande, om inte besvärsmyndigheten bestämmer något annat. Bestämmelser om verkställbarheten av vite och påföljdsavgift finns i lagen om verkställighet av böter.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_4__sec_26">
+                        <num>26 §</num>
+                        <heading eId="chp_4__sec_26__heading">Straffbestämmelser</heading>
+                        <subsection eId="chp_4__sec_26__subsec_1">
+                            <content>
+                                <p>Bestämmelser om straff för dataskyddsbrott finns i 38 kap. 9 § i strafflagen. Bestämmelser om straff för kränkning av kommunikationshemlighet och för grov kränkning av kommunikationshemlighet finns i 38 kap. 3 och 4 § i strafflagen och bestämmelser om straff för dataintrång och för grovt dataintrång i 38 kap. 8 och 8 a § i den lagen. Till straff för brott mot tystnadsplikten enligt 35 § i denna lag och mot sekretessen enligt 36 § döms enligt 38 kap. 1 eller 2 § i strafflagen, om inte gärningen utgör brott enligt 40 kap. 5 § i strafflagen eller om inte strängare straff för den föreskrivs någon annanstans i lag.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_4__sec_26__subsec_2">
+                            <content>
+                                <p>I 38 kap. 10 § 3 mom. i strafflagen finns det bestämmelser om åklagarens skyldighet att höra dataombudsmannen innan åtal väcks för brott som nämns i 1 mom. i denna paragraf liksom om domstolens skyldighet att ge dataombudsmannen tillfälle att bli hörd när domstolen behandlar ett sådant mål.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_5">
+                    <num>5 kap.</num>
+                    <heading eId="chp_5__heading">Särskilda behandlingssituationer</heading>
+                    <section eId="chp_5__sec_27">
+                        <num>27 §</num>
+                        <heading eId="chp_5__sec_27__heading">Behandling av personuppgifter för journalistiska, akademiska, konstnärliga eller litterära ändamål</heading>
+                        <subsection eId="chp_5__sec_27__subsec_1">
+                            <content>
+                                <p>För att trygga yttrandefriheten och informationsfriheten ska artikel 5.1 c–e, artiklarna 6 och 7, artiklarna 9 och 10, artikel 11.2, artiklarna 12–22, artikel 30, artikel 34.1–34.3, artiklarna 35 och 36, artikel 56, artikel 58.2 f, artiklarna 60–63 och artiklarna 65–67 i dataskyddsförordningen inte tillämpas på behandling av personuppgifter som sker för enbart journalistiska ändamål eller för akademiskt, konstnärligt eller litterärt skapande.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_27__subsec_2">
+                            <content>
+                                <p>
+                                    Artikel 27 i dataskyddsförordningen ska inte tillämpas på behandling av personuppgifter i samband med sådan verksamhet som omfattas av lagen om yttrandefrihet i masskommunikation 
+                                    <ref href="/akn/fi/act/statute-consolidated/2003/460">(460/2003)</ref>. Artiklarna 44–50 i dataskyddsförordningen ska inte tillämpas, om tillämpningen skulle kränka rätten till yttrandefrihet eller informationsfrihet.
+                                </p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_27__subsec_3">
+                            <content>
+                                <p>För att trygga yttrandefriheten och informationsfriheten ska artikel 5.1 a och b, artikel 5.2, artiklarna 24–26, artikel 31, artiklarna 39 och 40, artikel 42, artiklarna 57 och 58, artikel 64 och artikel 70 i dataskyddsförordningen endast tillämpas i tillämpliga delar på behandling av personuppgifter som sker för enbart journalistiska ändamål eller för akademiskt, konstnärligt eller litterärt skapande.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_28">
+                        <num>28 §</num>
+                        <heading eId="chp_5__sec_28__heading">Offentlighetsprincipen</heading>
+                        <subsection eId="chp_5__sec_28__subsec_1">
+                            <content>
+                                <p>På rätten att få uppgifter ur myndigheternas personregister och på annat utlämnande av personuppgifter ur dessa personregister tillämpas vad som föreskrivs om offentlighet i myndigheternas verksamhet.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_29v20231225" finlex:originalVersion="@20231225" finlex:originalVersionLabel="21.12.2023/1225">
+                        <num>29 §</num>
+                        <heading eId="chp_5__sec_29v20231225__heading">Behandling av personbeteckningar</heading>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_1v20231225">
+                            <intro eId="chp_5__sec_29v20231225__subsec_1v20231225__intro">
+                                <p>
+                                    En personbeteckning får behandlas med den registrerades samtycke eller när behandlingen regleras i lag. Dessutom får en personbeteckning behandlas, om det är viktigt att entydigt särskilja den registrerade och den registrerades personuppgifter från andra registrerade och deras personuppgifter (<i>specificering</i>)
+                                </p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_29v20231225__subsec_1v20231225__para_1v20231225">
+                                <num>1)</num>
+                                <content>
+                                    <p>för att utföra en i lag angiven uppgift,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_29v20231225__subsec_1v20231225__para_2v20231225">
+                                <num>2)</num>
+                                <content>
+                                    <p>för att tillgodose den registrerades eller den personuppgiftsansvariges rättigheter och uppfylla den registrerades eller den personuppgiftsansvariges skyldigheter, eller</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_29v20231225__subsec_1v20231225__para_3v20231225">
+                                <num>3)</num>
+                                <content>
+                                    <p>för historisk eller vetenskaplig forskning eller för statistikföring.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_2v20231225">
+                            <content>
+                                <p>En personbeteckning får behandlas för entydig specificering av den registrerade vid kreditgivning och indrivning av fordringar, i försäkrings-, kreditinstituts-, betaltjänst-, uthyrnings- och utlåningsverksamhet, i kreditupplysningsverksamhet, inom hälso- och sjukvården, inom socialvården och inom annan verksamhet för att tillförsäkra social trygghet samt i ärenden som gäller tjänste- och arbetsavtalsförhållanden och andra anställningsförhållanden och förmåner som har samband med dessa.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_3v20231225">
+                            <content>
+                                <p>Utöver vad som i 1 och 2 mom. föreskrivs om behandling av personbeteckningar får en personbeteckning lämnas ut för sådan databehandling som sker i syfte att uppdatera adressuppgifter eller undvika mångfaldig postning, om mottagaren redan har tillgång till personbeteckningen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_4v20231225">
+                            <content>
+                                <p>En personbeteckning får inte onödigtvis antecknas i handlingar som skrivs ut eller upprättas på basis av ett register.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_29v20231225__subsec_5v20231225">
+                            <content>
+                                <p>
+                                    Enbart personbeteckningen eller en kombination av personbeteckningen och den registrerades namn får inte användas för utredning av den registrerades identitet med hjälp av uppgifter som den registrerade har uppgett eller lämnat eller med hjälp av handlingar som den registrerade har visat upp (<i>identifiering</i>).
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_30">
+                        <num>30 §</num>
+                        <heading eId="chp_5__sec_30__heading">Behandling av personuppgifter i anställningsförhållanden</heading>
+                        <subsection eId="chp_5__sec_30__subsec_1">
+                            <content>
+                                <p>
+                                    Bestämmelser om behandling av anställdas personuppgifter, test och kontroller som anställda ska genomgå och de krav som ställs på dessa, teknisk övervakning på arbetsplatsen samt hämtning och öppnande av anställdas e-postmeddelanden finns i lagen om integritetsskydd i arbetslivet 
+                                    <ref href="/akn/fi/act/statute-consolidated/2004/759">(759/2004)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_31">
+                        <num>31 §</num>
+                        <heading eId="chp_5__sec_31__heading">Undantag och skyddsåtgärder som avser behandling av personuppgifter för vetenskapliga och historiska forskningsändamål samt statistiska ändamål</heading>
+                        <subsection eId="chp_5__sec_31__subsec_1">
+                            <intro eId="chp_5__sec_31__subsec_1__intro">
+                                <p>När personuppgifter behandlas för vetenskapliga eller historiska forskningsändamål får undantag vid behov göras från den registrerades rättigheter enligt artiklarna 15, 16, 18 och 21 i dataskyddsförordningen, under förutsättning att</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_31__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>behandlingen av uppgifterna grundar sig på en ändamålsenlig forskningsplan,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>det finns en ansvarig person eller en grupp som ansvarar för forskningen, och</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>personuppgifterna används och lämnas ut endast för historisk eller vetenskaplig forskning eller ett annat förenligt ändamål och verksamheten också i övrigt bedrivs så att uppgifter om bestämda personer inte röjs för utomstående.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_31__subsec_2">
+                            <intro eId="chp_5__sec_31__subsec_2__intro">
+                                <p>När personuppgifter behandlas för statistiska ändamål får undantag vid behov göras från den registrerades rättigheter enligt artiklarna 15, 16, 18 och 21 i dataskyddsförordningen, under förutsättning att</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_31__subsec_2__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>statistiken inte kan tas fram eller det informationsbehov som ligger till grund för den inte kan tillgodoses utan att personuppgifter behandlas,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_2__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>framtagandet av statistiken har en saklig anknytning till den personuppgiftsansvariges verksamhet, och</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_31__subsec_2__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>uppgifter inte lämnas ut eller görs tillgängliga på ett sådant sätt att de kan hänföras till någon bestämd person, om inte uppgifterna lämnas ut för officiell statistik.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_31__subsec_3">
+                            <content>
+                                <p>När personuppgifter som avses i artikel 9.1 och artikel 10 i dataskyddsförordningen behandlas för ett ändamål enligt 1 eller 2 mom. krävs det för ett undantag från den registrerades rättigheter enligt artiklarna 15, 16, 18 och 21 i dataskyddsförordningen, utöver vad som föreskrivs i 1 och 2 mom., att det utförs en konsekvensbedömning avseende dataskydd enligt artikel 35 i dataskyddsförordningen eller att en i artikel 40 i dataskyddsförordningen avsedd uppförandekod följs och att koden på behörigt sätt beaktar ovan avsedda möjlighet att göra undantag från den registrerades rättigheter. Konsekvensbedömningen ska skriftligen delges dataombudsmannen innan behandlingen inleds.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_32">
+                        <num>32 §</num>
+                        <heading eId="chp_5__sec_32__heading">Undantag och skyddsåtgärder som avser behandling av personuppgifter för arkivändamål av allmänt intresse</heading>
+                        <subsection eId="chp_5__sec_32__subsec_1">
+                            <content>
+                                <p>När personuppgifter behandlas med stöd av 4 § 4 punkten eller artikel 6.1 c i dataskyddsförordningen för arkivändamål av allmänt intresse får undantag göras från den registrerades rättigheter enligt artiklarna 15, 16 och 18–21 i dataskyddsförordningen under de förutsättningar som anges i artikel 89.3 i dataskyddsförordningen.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_33">
+                        <num>33 §</num>
+                        <heading eId="chp_5__sec_33__heading">Begränsningar i den personuppgiftsansvariges skyldighet att tillhandahålla de registrerade information</heading>
+                        <subsection eId="chp_5__sec_33__subsec_1">
+                            <content>
+                                <p>Undantag från skyldigheten enligt artiklarna 13 och 14 i dataskyddsförordningen att tillhandahålla den registrerade information får göras, om det är nödvändigt med hänsyn till statens säkerhet, försvaret eller allmän ordning och säkerhet eller för förebyggande eller utredande av brott eller för tillsynsuppgifter som anknyter till beskattningen eller den offentliga ekonomin.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_33__subsec_2">
+                            <content>
+                                <p>Undantag från artikel 14.1–14.4 i dataskyddsförordningen får också göras om tillhandahållandet av information orsakar väsentlig skada eller olägenhet för den registrerade och de uppgifter som registreras inte används för sådant beslutsfattande som gäller den registrerade.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_33__subsec_3">
+                            <content>
+                                <p>Om den registrerade enligt 1 eller 2 mom. inte tillhandahålls information, ska den personuppgiftsansvarige vidta lämpliga åtgärder till skydd för den registrerades rättigheter. I dessa åtgärder ingår att hålla den information som avses i artikel 14.1 och 14.2 i dataskyddsförordningen allmänt tillgänglig, om inte detta äventyrar syftet med begränsningen som gäller tillhandahållande av information.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_5__sec_34">
+                        <num>34 §</num>
+                        <heading eId="chp_5__sec_34__heading">Begränsningar i den registrerades rätt att få tillgång till de uppgifter som samlats in om honom eller henne</heading>
+                        <subsection eId="chp_5__sec_34__subsec_1">
+                            <intro eId="chp_5__sec_34__subsec_1__intro">
+                                <p>En registrerad har inte i artikel 15 i dataskyddsförordningen avsedd rätt att få tillgång till uppgifter som samlats in om honom eller henne, om</p>
+                            </intro>
+                            <paragraph eId="chp_5__sec_34__subsec_1__para_1">
+                                <num>1)</num>
+                                <content>
+                                    <p>lämnandet av informationen kan skada den nationella säkerheten, försvaret eller allmän ordning och säkerhet eller försvåra förebyggande eller utredning av brott,</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_34__subsec_1__para_2">
+                                <num>2)</num>
+                                <content>
+                                    <p>lämnandet av informationen kan medföra allvarlig fara för den registrerades hälsa eller vård eller för den registrerades eller någon annans rättigheter, eller</p>
+                                </content>
+                            </paragraph>
+                            <paragraph eId="chp_5__sec_34__subsec_1__para_3">
+                                <num>3)</num>
+                                <content>
+                                    <p>personuppgifterna används för tillsyns- och kontrolluppgifter och det för att trygga ett viktigt ekonomiskt eller finansiellt intresse för Finland eller Europeiska unionen är nödvändigt att informationen inte lämnas.</p>
+                                </content>
+                            </paragraph>
+                        </subsection>
+                        <subsection eId="chp_5__sec_34__subsec_2">
+                            <content>
+                                <p>Om endast en del av de uppgifter som gäller den registrerade är sådana att de enligt 1 mom. inte omfattas av rätten enligt artikel 15 i dataskyddsförordningen, har den registrerade rätt att få tillgång till de övriga uppgifter som rör honom eller henne.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_34__subsec_3">
+                            <content>
+                                <p>Den registrerade ska underrättas om orsakerna till begränsningen, om detta inte äventyrar syftet med begränsningen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_5__sec_34__subsec_4">
+                            <content>
+                                <p>Om den registrerade inte har rätt att bekanta sig med uppgifter som samlats in om honom eller henne, ska de uppgifter som avses i artikel 15.1 i dataskyddsförordningen lämnas till dataombudsmannen på begäran av den registrerade.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+                <chapter eId="chp_6">
+                    <num>6 kap.</num>
+                    <heading eId="chp_6__heading">Särskilda bestämmelser</heading>
+                    <section eId="chp_6__sec_35">
+                        <num>35 §</num>
+                        <heading eId="chp_6__sec_35__heading">Tystnadsplikt</heading>
+                        <subsection eId="chp_6__sec_35__subsec_1">
+                            <content>
+                                <p>Den som vid utförandet av åtgärder som har samband med behandlingen av personuppgifter har fått kännedom om något som gäller en annan persons egenskaper, personliga förhållanden, ekonomiska ställning eller någon annans företagshemligheter får inte obehörigen för utomstående röja de uppgifter som han eller hon erhållit på detta sätt eller använda uppgifterna för sin egen eller någon annans vinning eller för att skada någon annan.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_36">
+                        <num>36 §</num>
+                        <heading eId="chp_6__sec_36__heading">Skydd för rapportörers identitet</heading>
+                        <subsection eId="chp_6__sec_36__subsec_1">
+                            <content>
+                                <p>När en fysisk person har rapporterat till dataombudsmannen om en misstänkt överträdelse av bestämmelser som omfattas av dataombudsmannens tillsyn, ska rapportörens identitet hållas hemlig, om det utifrån omständigheterna kan bedömas vara till nackdel för rapportören att hans eller hennes identitet röjs.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_36av20260380" finlex:originalVersion="@20260380" finlex:originalVersionLabel="22.5.2026/380">
+                        <num>36 a §</num>
+                        <heading eId="chp_6__sec_36av20260380__heading">Ackreditering av certifieringsorgan</heading>
+                        <subsection eId="chp_6__sec_36av20260380__subsec_1v20260380">
+                            <content>
+                                <p>Det nationella ackrediteringsorganet ackrediterar sådana certifieringsorgan som avses i artikel 43 i dataskyddsförordningen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_36av20260380__subsec_2v20260380">
+                            <content>
+                                <p>Teknisk sakkunnig vid ackrediteringen är i första hand dataombudsmannen och i andra hand en sakkunnig som utsetts av det nationella ackrediteringsorganet. Om en sakkunnig som utsetts av det nationella ackrediteringsorganet är teknisk sakkunnig, ska dataombudsmannen ges tillfälle att innan ackrediteringen beviljas uttala sig om uppfyllandet av de förutsättningar som gäller dataskydd och som avses i artikel 43.2 och 43.3 i dataskyddsförordningen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_36av20260380__subsec_3v20260380">
+                            <content>
+                                <p>Det nationella ackrediteringsorganet bestämmer och tar ut avgifter till staten för ackrediterings- och bedömningstjänster som utförts med stöd av denna paragraf. Dataombudsmannens byrå har rätt att få ersättning av det nationella ackrediteringsorganet för utförandet av uppgifter enligt denna paragraf.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <hcontainer eId="note_10" finlex:outline="huomautus" name="noteAuthorial">
+                        <content>
+                            <p>
+                                36 a § har tillfogats genom L 
+                                <ref href="/akn/fi/act/statute/2026/380">380/2026</ref>, som träder i kraft 1.9.2026.
+                            </p>
+                        </content>
+                    </hcontainer>
+                    <section eId="chp_6__sec_37" finlex:entryIntoForce="true" finlex:vsId="1050/2018">
+                        <num>37 §</num>
+                        <heading eId="chp_6__sec_37__heading">Ikraftträdande</heading>
+                        <subsection eId="chp_6__sec_37__subsec_1">
+                            <content>
+                                <p>Denna lag träder i kraft den 1 januari 2019.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_37__subsec_2">
+                            <content>
+                                <p>
+                                    Genom denna lag upphävs personuppgiftslagen 
+                                    <ref href="/akn/fi/act/statute-consolidated/1999/523">(523/1999)</ref>
+                                     och lagen om datasekretessnämnden och dataombudsmannen 
+                                    <ref href="/akn/fi/act/statute-consolidated/1994/389">(389/1994)</ref>.
+                                </p>
+                            </content>
+                        </subsection>
+                    </section>
+                    <section eId="chp_6__sec_38" finlex:entryIntoForce="true" finlex:vsId="1050/2018">
+                        <num>38 §</num>
+                        <heading eId="chp_6__sec_38__heading">Övergångsbestämmelser</heading>
+                        <subsection eId="chp_6__sec_38__subsec_1">
+                            <content>
+                                <p>Giltigheten av de tillstånd som beviljats av datasekretessnämnden upphör vid ikraftträdandet av denna lag. Ärenden som före ikraftträdandet av denna lag blivit anhängiga i datasekretessnämnden förfaller vid ikraftträdandet.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_2">
+                            <content>
+                                <p>På ett vid ikraftträdandet av denna lag anhängigt ärende som gäller en anmälan till dataombudsmannen tillämpas de bestämmelser i 36 och 37 § i personuppgiftslagen som gäller anmälningsplikt och hur en anmälan ska göras.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_3">
+                            <content>
+                                <p>På ett vid ikraftträdandet av denna lag anhängigt ärende som gäller utövande av rätten till insyn och rättelse av personuppgifter tillämpas inte de bestämmelser i artiklarna 12 och 15–18 i dataskyddsförordningen enligt vilka den personuppgiftsansvarige åläggs mer omfattande skyldigheter än vad den registeransvarige hade enligt de bestämmelser som gällde vid ikraftträdandet av denna lag, om det med avseende på den personuppgiftsansvarige skulle vara oskäligt att tillämpa de nämnda bestämmelserna i dataskyddsförordningen.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_4">
+                            <content>
+                                <p>Vid överklagande av beslut som datasekretessnämnden och dataombudsmannen fattat före ikraftträdandet av denna lag tillämpas de bestämmelser som gällde vid ikraftträdandet. På extraordinärt ändringssökande tillämpas de bestämmelser som gällde vid ikraftträdandet av denna lag dock endast om ändringssökandet inletts före ikraftträdandet.</p>
+                            </content>
+                        </subsection>
+                        <subsection eId="chp_6__sec_38__subsec_5">
+                            <content>
+                                <p>Om en gärning som orsakat skada har begåtts före ikraftträdandet av denna lag tillämpas de bestämmelser som gällde vid ikraftträdandet på skyldigheten att ersätta skadan.</p>
+                            </content>
+                        </subsection>
+                    </section>
+                </chapter>
+            </hcontainer>
+            <hcontainer finlex:outline="Förarbeten och signaturer" name="conclusions">
+                <hcontainer finlex:outline="Förarbeten" name="preliminaryWork">
+                    <content>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2018/9">RP 9/2018</ref>
+                        </p>
+                        <p>FvUB 13/2018</p>
+                        <p>RSv 108/2018</p>
+                        <p>Europaparlamentets och rådets förordning (EU) nr 679/2016 (32016R0679); EUT L 119, 4.5.2016, s. 1</p>
+                    </content>
+                </hcontainer>
+            </hcontainer>
+            <hcontainer name="amendmentEntryIntoForceAndApplianceProvisions">
+                <heading>Ikraftträdelsestadganden</heading>
+                <hcontainer eId="entryIntoForce_20200869" name="entryIntoForce">
+                    <heading>27.11.2020/869:</heading>
+                    <content>
+                        <p>Denna lag träder i kraft den 1 december 2020.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2020/109">RP 109/2020</ref>, LaUB 10/2020, RSv 136/2020
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20200902" name="entryIntoForce">
+                    <heading>27.11.2020/902:</heading>
+                    <content>
+                        <p>Denna lag träder i kraft den 10 december 2020.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2020/30">RP 30/2020</ref>, FvUB 16/2020, RSv 125/2020
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20221112" name="entryIntoForce">
+                    <heading>20.12.2022/1112:</heading>
+                    <content>
+                        <p>Denna lag träder i kraft den 25 juni 2023. </p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2022/111">RP 111/2022</ref>, LaUB 20/2022, RSv 204/2022, Europaparlamentets och rådets direktiv (EU) 2020/1828 (32020L1828); EUT L 409, 4.12.2020, s.1
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20230239" name="entryIntoForce">
+                    <heading>16.2.2023/239:</heading>
+                    <content>
+                        <p>Denna lag träder i kraft den 1 mars 2023.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2022/93">RP 93/2022</ref>, LaUB 25/2022, RSv 252/2022
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20231225" name="entryIntoForce">
+                    <heading>21.12.2023/1225:</heading>
+                    <content>
+                        <p>Denna lag träder i kraft den 1 januari 2024.</p>
+                        <p>Bestämmelserna i 21 § 3 och 4 mom. i denna lag tillämpas inte på ärenden som är under behandling hos dataombudsmannen vid ikraftträdandet av lagen.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2023/62">RP 62/2023</ref>, FvUB 9/2023, RSv 55/2023
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20240029" name="entryIntoForce">
+                    <heading>12.1.2024/29:</heading>
+                    <content>
+                        <p>Denna lag träder i kraft den 1 januari 2025.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2023/31">RP 31/2023</ref>, LaUB 6/2023, RSv 47/2023
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20250437" name="entryIntoForce">
+                    <heading>27.6.2025/437:</heading>
+                    <content>
+                        <p>Denna lag träder i kraft den 1 januari 2026.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2025/5">RP 5/2025</ref>, LaUB 6/2025, RSv 52/2025
+                        </p>
+                    </content>
+                </hcontainer>
+                <hcontainer eId="entryIntoForce_20260380" name="entryIntoForce">
+                    <heading>22.5.2026/380:</heading>
+                    <content>
+                        <p>Denna lag träder i kraft den 1 september 2026.</p>
+                        <p>
+                            <ref href="/akn/fi/doc/government-proposal/2026/9">RP 9/2026</ref>, FvUB 4/2026, RSv 46/2026
+                        </p>
+                    </content>
+                </hcontainer>
+            </hcontainer>
+        </body>
+    </act>
+</akomaNtoso>

--- a/tests/ingest/bulk-helpers.test.ts
+++ b/tests/ingest/bulk-helpers.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Bulk-sweep operability tests (PR #79 round-2):
+ *  - transport-outage abort: only HTTP 429 aborted the sweep; a sustained
+ *    network outage burned every remaining candidate at ~16s each (observed
+ *    live: 269 consecutive transport failures, ~75-90 min wasted).
+ *  - durable run-stamped reports: the report was written ONLY after loop
+ *    completion to a fixed overwritten filename — a killed sweep left no
+ *    record at all (Dutch round-2 lesson: run-stamped report files).
+ *  - the refresh contract (`npm run ingest:refresh`) must walk the EXISTING
+ *    corpus (--seeds-only): list-driven refresh silently expands the corpus
+ *    and reuses a stale cached catalogue.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  classifyIngestFailure,
+  runReportPath,
+  TRANSPORT_ABORT_THRESHOLD,
+} from '../../scripts/ingest-finlex-bulk.js';
+
+describe('classifyIngestFailure', () => {
+  it('recognizes rate limiting (429) — aborts immediately as before', () => {
+    expect(classifyIngestFailure('HTTP 429 from Finlex list endpoint')).toBe('rate_limited');
+    expect(
+      classifyIngestFailure('fetch https://x failed after 4 attempts: HTTP 429')
+    ).toBe('rate_limited');
+  });
+
+  it('recognizes exhausted-retry transport failures (network outage / persistent 5xx)', () => {
+    expect(
+      classifyIngestFailure('fetch https://opendata.finlex.fi/... failed after 4 attempts: fetch failed')
+    ).toBe('transport');
+    expect(
+      classifyIngestFailure('fetch https://opendata.finlex.fi/... failed after 4 attempts: HTTP 503')
+    ).toBe('transport');
+  });
+
+  it('leaves per-document failures (parse errors, identity mismatches, zero provisions) as other', () => {
+    expect(classifyIngestFailure('Body identity mismatch for X')).toBe('other');
+    expect(classifyIngestFailure('document parsed to ZERO provisions')).toBe('other');
+  });
+
+  it('exposes a sane consecutive-failure threshold', () => {
+    expect(TRANSPORT_ABORT_THRESHOLD).toBeGreaterThanOrEqual(3);
+    expect(TRANSPORT_ABORT_THRESHOLD).toBeLessThanOrEqual(10);
+  });
+});
+
+describe('runReportPath (durable run-stamped reports)', () => {
+  it('derives a per-run filename from the start timestamp (no fixed-name overwrites)', () => {
+    const p = runReportPath('2026-06-11T03:00:00.123Z');
+    expect(path.basename(p)).toBe('finlex-bulk-run-2026-06-11T03-00-00Z.json');
+    expect(p).toContain(`reports${path.sep}ingest`);
+  });
+
+  it('two runs get two distinct report files', () => {
+    expect(runReportPath('2026-06-11T03:00:00.000Z')).not.toBe(runReportPath('2026-06-11T04:30:01.000Z'));
+  });
+});
+
+describe('refresh contract', () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+  it('npm run ingest:refresh walks the existing corpus (--refresh AND --seeds-only)', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8')) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts['ingest:refresh']).toContain('--refresh');
+    expect(pkg.scripts['ingest:refresh']).toContain('--seeds-only');
+  });
+
+  it('gitignores the forensic source-cache and run-stamped reports', () => {
+    const gitignore = fs.readFileSync(path.join(repoRoot, '.gitignore'), 'utf-8');
+    expect(gitignore).toContain('data/source-cache/');
+    expect(gitignore).toContain('reports/ingest/finlex-bulk-run-');
+  });
+});

--- a/tests/ingest/check-updates.test.ts
+++ b/tests/ingest/check-updates.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Freshness-classification tests (PR #79 round-2).
+ *
+ * Two defect classes locked down here:
+ *  - check-updates:241 — "stamped as-enacted" (doc_type 'statute',
+ *    consolidation_version null: the legitimate consolidated-404 cohort,
+ *    ~60% of the corpus) was conflated with "unstamped". The stamp EXISTS and
+ *    proves the as-enacted expression; flagging it update-needed made the
+ *    checker exit 1 forever (re-ingest reproduces the same stamp).
+ *  - check-updates:253 — absence from the upstream consolidated list was
+ *    conflated with "no consolidated work upstream" even for seeds whose
+ *    stamp PROVES a consolidation existed; plus list entries that stopped
+ *    matching the URI regex were dropped silently (no counter, no failure).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  classifySeedFreshness,
+  collectNewestVersions,
+  assertListShape,
+} from '../../scripts/check-updates.js';
+
+describe('classifySeedFreshness', () => {
+  it('flags UNSTAMPED seeds: freshness unprovable, re-ingest', () => {
+    const verdict = classifySeedFreshness(null, null);
+    expect(verdict.has_update).toBe(true);
+    expect(verdict.error).toMatch(/unprovable/iu);
+  });
+
+  it('stamped AS-ENACTED with no consolidated work upstream is UP TO DATE (not "unstamped")', () => {
+    const verdict = classifySeedFreshness(
+      { doc_type: 'statute', consolidation_version: null, content_absent_version: null },
+      null
+    );
+    expect(verdict.has_update).toBe(false);
+    expect(verdict.error).toBeUndefined();
+  });
+
+  it('stamped AS-ENACTED gains an update when a consolidation APPEARS upstream', () => {
+    const verdict = classifySeedFreshness(
+      { doc_type: 'statute', consolidation_version: null, content_absent_version: null },
+      '20260380'
+    );
+    expect(verdict.has_update).toBe(true);
+    expect(verdict.error).toMatch(/appeared/iu);
+  });
+
+  it('compares stamped consolidated seeds against the upstream version', () => {
+    const stamp = { doc_type: 'statute-consolidated' as const, consolidation_version: '20230239', content_absent_version: null };
+    expect(classifySeedFreshness(stamp, '20260380').has_update).toBe(true);
+    expect(classifySeedFreshness(stamp, '20230239').has_update).toBe(false);
+  });
+
+  it('treats a stamped-CONSOLIDATED seed missing from the upstream list as a LOUD anomaly, not up-to-date', () => {
+    const verdict = classifySeedFreshness(
+      { doc_type: 'statute-consolidated', consolidation_version: '20230239', content_absent_version: null },
+      null
+    );
+    expect(verdict.has_update).toBe(true);
+    expect(verdict.error).toMatch(/anomal/iu);
+  });
+
+  it('compares contentAbsent-fallback seeds via the stamped SHELL version (no permanent re-flag loop)', () => {
+    const stamp = { doc_type: 'statute' as const, consolidation_version: null, content_absent_version: '20050045' };
+    expect(classifySeedFreshness(stamp, '20050045').has_update).toBe(false);
+    expect(classifySeedFreshness(stamp, '20260001').has_update).toBe(true);
+  });
+
+  it('flags stamps with unparseable consolidation tokens as unprovable', () => {
+    const verdict = classifySeedFreshness(
+      { doc_type: 'statute-consolidated', consolidation_version: 'garbage', content_absent_version: null },
+      '20260380'
+    );
+    expect(verdict.has_update).toBe(true);
+    expect(verdict.error).toMatch(/unprovable/iu);
+  });
+});
+
+describe('consolidated-list parsing (no silent regex drops)', () => {
+  const fin = (uri: string) => ({ akn_uri: uri });
+
+  it('collects the newest fin@ version per statute and counts what it saw', () => {
+    const versions = new Map<string, string>();
+    const stats = collectNewestVersions(
+      [
+        fin('https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute-consolidated/2018/1050/fin@20230239'),
+        fin('/akn/fi/act/statute-consolidated/2018/1050/fin@20260380'),
+        fin('/akn/fi/act/statute-consolidated/2018/1050/swe@20260380'),
+      ],
+      versions
+    );
+    expect(versions.get('1050/2018')).toBe('20260380');
+    expect(stats.finCount).toBe(2);
+    expect(stats.otherLanguageCount).toBe(1);
+    expect(stats.unrecognized).toEqual([]);
+  });
+
+  it('records UNRECOGNIZED entries instead of dropping them silently', () => {
+    const versions = new Map<string, string>();
+    const stats = collectNewestVersions(
+      [fin('/akn/fi/act/some-new-doctype/2018/1050/fin@20260380'), { akn_uri: undefined }],
+      versions
+    );
+    expect(stats.unrecognized).toHaveLength(2);
+  });
+
+  it('assertListShape fails loud on unrecognized entries (shape drift)', () => {
+    expect(() =>
+      assertListShape({ entriesSeen: 3, finCount: 2, otherLanguageCount: 0, unrecognized: ['/akn/weird'] }, '2018')
+    ).toThrow(/unrecognized/iu);
+  });
+
+  it('assertListShape fails loud when entries exist but NONE parsed as fin@ (zero-parse drift)', () => {
+    expect(() =>
+      assertListShape({ entriesSeen: 10, finCount: 0, otherLanguageCount: 10, unrecognized: [] }, '2018')
+    ).toThrow(/zero|none/iu);
+  });
+
+  it('assertListShape accepts an empty year (no consolidated works is a valid state)', () => {
+    expect(() =>
+      assertListShape({ entriesSeen: 0, finCount: 0, otherLanguageCount: 0, unrecognized: [] }, '1899')
+    ).not.toThrow();
+  });
+});

--- a/tests/ingest/check-updates.test.ts
+++ b/tests/ingest/check-updates.test.ts
@@ -121,3 +121,23 @@ describe('consolidated-list parsing (no silent regex drops)', () => {
     ).not.toThrow();
   });
 });
+
+describe('bare-@ consolidated list entries (PR #79 round 3)', () => {
+  // Live-verified: never-amended consolidations appear ONLY as bare-@ akn_uris
+  // (empty version token) while the served document carries FRBRversionNumber.
+  it('a stamped-consolidated seed with a bare-@ remote entry is CURRENT, not an anomaly', () => {
+    const verdict = classifySeedFreshness(
+      { doc_type: 'statute-consolidated', consolidation_version: '19990005', content_absent_version: null },
+      '',
+    );
+    expect(verdict.has_update).toBe(false);
+  });
+
+  it('a stamped as-enacted seed with a bare-@ remote entry IS stale (a consolidation exists upstream)', () => {
+    const verdict = classifySeedFreshness(
+      { doc_type: 'statute', consolidation_version: null, content_absent_version: null },
+      '',
+    );
+    expect(verdict.has_update).toBe(true);
+  });
+});

--- a/tests/ingest/finlex-http.test.ts
+++ b/tests/ingest/finlex-http.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Transient-vs-gone HTTP discipline (issue #78, port of dutch-law-mcp http-retry).
+ *
+ * Transient failures (5xx, 429, network throw) retry then THROW — they may
+ * never be soft-failed into "document gone upstream". 404 is returned to the
+ * caller: a 404 on statute-consolidated IS a finding (no consolidation
+ * published), not an error.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fetchWithRetry } from '../../scripts/lib/finlex-http.js';
+
+const NO_BACKOFF = { backoffMs: [0, 0, 0] };
+
+function response(status: number, body = ''): Response {
+  return new Response(body, { status });
+}
+
+describe('fetchWithRetry', () => {
+  it('returns an ok response directly', async () => {
+    const fetchImpl = vi.fn(async () => response(200, '<xml/>'));
+    const res = await fetchWithRetry('https://x/y', { fetchImpl, ...NO_BACKOFF });
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 404 to the caller without retrying — gone is a finding', async () => {
+    const fetchImpl = vi.fn(async () => response(404));
+    const res = await fetchWithRetry('https://x/y', { fetchImpl, ...NO_BACKOFF });
+    expect(res.status).toBe(404);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries 5xx then succeeds', async () => {
+    const fetchImpl = vi
+      .fn<Parameters<typeof fetch>, Promise<Response>>()
+      .mockResolvedValueOnce(response(500))
+      .mockResolvedValueOnce(response(503))
+      .mockResolvedValueOnce(response(200, 'ok'));
+    const res = await fetchWithRetry('https://x/y', { fetchImpl, ...NO_BACKOFF });
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries 429 (rate limit) then succeeds', async () => {
+    const fetchImpl = vi
+      .fn<Parameters<typeof fetch>, Promise<Response>>()
+      .mockResolvedValueOnce(response(429))
+      .mockResolvedValueOnce(response(200, 'ok'));
+    const res = await fetchWithRetry('https://x/y', { fetchImpl, ...NO_BACKOFF });
+    expect(res.status).toBe(200);
+  });
+
+  it('THROWS after exhausting attempts on persistent 5xx — never soft-fails to gone', async () => {
+    const fetchImpl = vi.fn(async () => response(502));
+    await expect(
+      fetchWithRetry('https://x/y', { fetchImpl, attempts: 3, ...NO_BACKOFF })
+    ).rejects.toThrow(/502/u);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('THROWS after exhausting attempts on network errors', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('ECONNRESET');
+    });
+    await expect(
+      fetchWithRetry('https://x/y', { fetchImpl, attempts: 2, ...NO_BACKOFF })
+    ).rejects.toThrow(/ECONNRESET/u);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes headers through (Finlex requires User-Agent)', async () => {
+    const fetchImpl = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      expect((init?.headers as Record<string, string>)['User-Agent']).toMatch(/Finnish-Law-MCP/u);
+      return response(200);
+    });
+    await fetchWithRetry('https://x/y', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      headers: { 'User-Agent': 'Finnish-Law-MCP/test' },
+      ...NO_BACKOFF,
+    });
+  });
+});

--- a/tests/ingest/finlex-version.test.ts
+++ b/tests/ingest/finlex-version.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Version-identity + refresh-policy tests (issue #78, port of dutch-law-mcp#119 fix).
+ *
+ * Fixtures are REAL Finlex open-data responses captured 2026-06-10:
+ *  - statute/2018/1050/fin@                       -> original as-enacted (alkup)
+ *  - statute-consolidated/2018/1050/fin@latest    -> consolidation 20260380 (ajantasa 2026-05-22)
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseVersionIdentity,
+  assertCurrentConsolidation,
+  compareVersionNumbers,
+  decideFetch,
+  decideRewrite,
+} from '../../scripts/lib/finlex-version.js';
+
+const FIXTURES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../fixtures/finlex');
+
+const consolidatedXml = fs.readFileSync(
+  path.join(FIXTURES, 'statute-consolidated-2018-1050-fin-latest.xml'),
+  'utf-8'
+);
+const originalXml = fs.readFileSync(
+  path.join(FIXTURES, 'statute-2018-1050-fin-original.xml'),
+  'utf-8'
+);
+
+describe('parseVersionIdentity', () => {
+  it('extracts the consolidation identity from a statute-consolidated expression', () => {
+    const id = parseVersionIdentity(consolidatedXml);
+    expect(id.doc_type).toBe('statute-consolidated');
+    expect(id.expression_uri).toBe('/akn/fi/act/statute-consolidated/2018/1050/fin@20260380');
+    expect(id.version_number).toBe('20260380');
+    expect(id.consolidated_to).toBe('2026-05-22');
+    expect(id.eli_uri).toBe('http://data.finlex.fi/eli/sd/2018/1050/ajantasa/2026-05-22/fin');
+    expect(id.language).toBe('fin');
+    expect(id.contains).toBe('multipleVersions');
+  });
+
+  it('extracts the as-enacted identity from an original statute expression', () => {
+    const id = parseVersionIdentity(originalXml);
+    expect(id.doc_type).toBe('statute');
+    expect(id.expression_uri).toBe('/akn/fi/act/statute/2018/1050/fin@');
+    expect(id.version_number).toBeNull();
+    expect(id.consolidated_to).toBeNull();
+    expect(id.eli_uri).toBe('http://data.finlex.fi/eli/sd/2018/1050/alkup/fin');
+    expect(id.contains).toBe('originalVersion');
+  });
+
+  it('fails loud on XML without an identification block', () => {
+    expect(() => parseVersionIdentity('<akomaNtoso><act/></akomaNtoso>')).toThrow(/identification/iu);
+  });
+});
+
+describe('assertCurrentConsolidation', () => {
+  it('accepts a consolidated (ajantasa) expression', () => {
+    expect(() => assertCurrentConsolidation(parseVersionIdentity(consolidatedXml))).not.toThrow();
+  });
+
+  it('rejects an original (alkup) expression — the exact defect of issue #78', () => {
+    expect(() => assertCurrentConsolidation(parseVersionIdentity(originalXml))).toThrow(/alkup|original/iu);
+  });
+});
+
+describe('compareVersionNumbers', () => {
+  it('orders YYYYNNNN consolidation tokens chronologically', () => {
+    expect(compareVersionNumbers('20181050', '20230239')).toBeLessThan(0);
+    expect(compareVersionNumbers('20230239', '20260380')).toBeLessThan(0);
+    expect(compareVersionNumbers('20260380', '20260380')).toBe(0);
+    expect(compareVersionNumbers('20260380', '20181050')).toBeGreaterThan(0);
+  });
+
+  it('orders zero-padded statute numbers within a year', () => {
+    // 987/2025 (zero-padded 20250987) precedes 1050/2025 (20251050)
+    expect(compareVersionNumbers('20250987', '20251050')).toBeLessThan(0);
+  });
+
+  it('fails loud on malformed tokens instead of guessing', () => {
+    expect(() => compareVersionNumbers('latest', '20260380')).toThrow();
+    expect(() => compareVersionNumbers('20260380', '')).toThrow();
+  });
+});
+
+describe('decideFetch (pre-network)', () => {
+  it('fetches when no seed exists', () => {
+    expect(decideFetch({ seedExists: false, refresh: false, stampedVersion: null })).toBe('fetch_new');
+    expect(decideFetch({ seedExists: false, refresh: true, stampedVersion: null })).toBe('fetch_new');
+  });
+
+  it('skips existing seeds outside refresh mode (resume behavior preserved)', () => {
+    expect(decideFetch({ seedExists: true, refresh: false, stampedVersion: '20260380' })).toBe('skip_existing');
+  });
+
+  it('self-heals unstamped seeds in refresh mode — every pre-fix seed must be re-acquired', () => {
+    expect(decideFetch({ seedExists: true, refresh: true, stampedVersion: null })).toBe('refetch_unknown');
+  });
+
+  it('probes stamped seeds in refresh mode (fin@latest is both probe and payload)', () => {
+    expect(decideFetch({ seedExists: true, refresh: true, stampedVersion: '20260380' })).toBe('refetch_check');
+  });
+});
+
+describe('decideRewrite (post-fetch)', () => {
+  it('rewrites when upstream consolidation is newer than the stamp', () => {
+    expect(decideRewrite({ stampedVersion: '20230239', fetchedVersion: '20260380' })).toBe('refetch_changed');
+  });
+
+  it('keeps the seed when versions are equal (no git churn)', () => {
+    expect(decideRewrite({ stampedVersion: '20260380', fetchedVersion: '20260380' })).toBe('skip_current');
+  });
+
+  it('rewrites when the stamp is missing or unparseable — freshness must be PROVEN', () => {
+    expect(decideRewrite({ stampedVersion: null, fetchedVersion: '20260380' })).toBe('refetch_unknown');
+    expect(decideRewrite({ stampedVersion: 'garbage', fetchedVersion: '20260380' })).toBe('refetch_unknown');
+  });
+
+  it('rewrites when upstream is OLDER than the stamp (inconsistent — re-stamp settles it)', () => {
+    expect(decideRewrite({ stampedVersion: '20260380', fetchedVersion: '20230239' })).toBe('refetch_unknown');
+  });
+
+  it('rewrites when the fetched expression carries no version (original as-enacted path)', () => {
+    expect(decideRewrite({ stampedVersion: null, fetchedVersion: null })).toBe('refetch_unknown');
+  });
+});

--- a/tests/ingest/finlex-version.test.ts
+++ b/tests/ingest/finlex-version.test.ts
@@ -15,6 +15,10 @@ import {
   compareVersionNumbers,
   decideFetch,
   decideRewrite,
+  parseLifecycle,
+  deriveSeedStatus,
+  stampedLanguageVersionsOf,
+  seedStampInfoOf,
 } from '../../scripts/lib/finlex-version.js';
 
 const FIXTURES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../fixtures/finlex');
@@ -25,6 +29,14 @@ const consolidatedXml = fs.readFileSync(
 );
 const originalXml = fs.readFileSync(
   path.join(FIXTURES, 'statute-2018-1050-fin-original.xml'),
+  'utf-8'
+);
+const repealedXml = fs.readFileSync(
+  path.join(FIXTURES, 'statute-consolidated-1999-523-fin-latest.xml'),
+  'utf-8'
+);
+const contentAbsentXml = fs.readFileSync(
+  path.join(FIXTURES, 'statute-consolidated-2005-45-fin-contentabsent.xml'),
   'utf-8'
 );
 
@@ -52,6 +64,149 @@ describe('parseVersionIdentity', () => {
 
   it('fails loud on XML without an identification block', () => {
     expect(() => parseVersionIdentity('<akomaNtoso><act/></akomaNtoso>')).toThrow(/identification/iu);
+  });
+
+  it('pins a bare-@ consolidated FRBRuri with the FRBRversionNumber (single-version consolidations)', () => {
+    // Upstream serves single-version consolidations with a BARE '@' FRBRuri —
+    // the exact ambiguous form the module header forbids (re-resolves to the
+    // OLDEST expression once a second version appears). The version number is
+    // in the same identification block, so the identity must be pinned.
+    const id = parseVersionIdentity(contentAbsentXml);
+    expect(id.doc_type).toBe('statute-consolidated');
+    expect(id.version_number).toBe('20050045');
+    expect(id.expression_uri).toBe('/akn/fi/act/statute-consolidated/2005/45/fin@20050045');
+  });
+});
+
+describe('parseLifecycle (finlex proprietary lifecycle metadata)', () => {
+  it('reads in-force lifecycle from a current consolidation', () => {
+    const lc = parseLifecycle(consolidatedXml);
+    expect(lc.is_in_force).toBe(true);
+    expect(lc.date_entry_into_force).toBe('2019-01-01');
+    expect(lc.date_in_force_end).toBeNull();
+    expect(lc.repealed_by).toEqual([]);
+  });
+
+  it('reads repealed lifecycle (isInForce=false + dateInForceEnd + repealedBy) — 523/1999', () => {
+    const lc = parseLifecycle(repealedXml);
+    expect(lc.is_in_force).toBe(false);
+    expect(lc.date_in_force_end).toBe('2018-12-31');
+    expect(lc.repealed_by).toEqual(['1050/2018']);
+    // Must read the TOP-LEVEL inForce block, not the nested ones inside
+    // finlex:amendedBy statute references (e.g. 1.1.2011 for 1049/2010).
+    expect(lc.date_entry_into_force).toBe('1999-06-01');
+  });
+
+  it('returns is_in_force=null when the document carries no lifecycle metadata (as-enacted originals)', () => {
+    const lc = parseLifecycle(originalXml);
+    expect(lc.is_in_force).toBeNull();
+    expect(lc.date_in_force_end).toBeNull();
+    expect(lc.repealed_by).toEqual([]);
+  });
+
+  it('fails loud on unknown isInForce vocabulary instead of guessing', () => {
+    const mangled = consolidatedXml.replace('finlex:isInForce value="true"', 'finlex:isInForce value="maybe"');
+    expect(() => parseLifecycle(mangled)).toThrow(/isInForce/u);
+  });
+});
+
+describe('deriveSeedStatus (status is a FACT from upstream metadata, never a constant)', () => {
+  const inForce = parseLifecycle(consolidatedXml);
+  const repealed = parseLifecycle(repealedXml);
+  const absent = parseLifecycle(originalXml);
+
+  it('maps isInForce=true to in_force', () => {
+    expect(deriveSeedStatus({ docType: 'statute-consolidated', lifecycle: inForce })).toEqual({
+      status: 'in_force',
+      basis: 'finlex_lifecycle_metadata',
+    });
+  });
+
+  it('maps isInForce=false with repealedBy/dateInForceEnd to repealed', () => {
+    expect(deriveSeedStatus({ docType: 'statute-consolidated', lifecycle: repealed })).toEqual({
+      status: 'repealed',
+      basis: 'finlex_lifecycle_metadata',
+    });
+  });
+
+  it('maps isInForce=false with a FUTURE entry-into-force date to not_yet_in_force', () => {
+    expect(
+      deriveSeedStatus({
+        docType: 'statute-consolidated',
+        lifecycle: { ...inForce, is_in_force: false, date_entry_into_force: '2099-01-01' },
+        today: '2026-06-11',
+      })
+    ).toEqual({ status: 'not_yet_in_force', basis: 'finlex_lifecycle_metadata' });
+  });
+
+  it('FAILS LOUD when a consolidated document carries no isInForce (shape drift)', () => {
+    expect(() => deriveSeedStatus({ docType: 'statute-consolidated', lifecycle: absent })).toThrow(
+      /isInForce|lifecycle/iu
+    );
+  });
+
+  it('as-enacted originals (no lifecycle metadata upstream) get the documented default, stamped as unverified', () => {
+    expect(deriveSeedStatus({ docType: 'statute', lifecycle: absent })).toEqual({
+      status: 'in_force',
+      basis: 'as_enacted_default_unverified',
+    });
+  });
+
+  it('uses lifecycle metadata on an as-enacted document when upstream does provide it', () => {
+    expect(deriveSeedStatus({ docType: 'statute', lifecycle: repealed })).toEqual({
+      status: 'repealed',
+      basis: 'finlex_lifecycle_metadata',
+    });
+  });
+});
+
+describe('stamp readers', () => {
+  const stampedSeed = {
+    _ingest: {
+      doc_type: 'statute-consolidated',
+      consolidation_version: '20260380',
+      languages: {
+        fin: { expression_uri: '/akn/fi/act/statute-consolidated/2018/1050/fin@20260380', consolidation_version: '20260380' },
+        swe: { expression_uri: '/akn/fi/act/statute-consolidated/2018/1050/swe@20260380', consolidation_version: '20260380' },
+      },
+    },
+  };
+
+  it('stampedLanguageVersionsOf reads per-language consolidation versions', () => {
+    expect(stampedLanguageVersionsOf(stampedSeed)).toEqual({ fin: '20260380', swe: '20260380' });
+  });
+
+  it('stampedLanguageVersionsOf surfaces a missing Swedish stamp (omitted-Swedish cohort)', () => {
+    const noSwe = JSON.parse(JSON.stringify(stampedSeed));
+    delete noSwe._ingest.languages.swe;
+    expect(stampedLanguageVersionsOf(noSwe)).toEqual({ fin: '20260380' });
+    expect(stampedLanguageVersionsOf({})).toBeNull();
+  });
+
+  it('seedStampInfoOf distinguishes stamped-as-enacted from unstamped', () => {
+    expect(seedStampInfoOf({ _ingest: { doc_type: 'statute', consolidation_version: null } })).toEqual({
+      doc_type: 'statute',
+      consolidation_version: null,
+      content_absent_version: null,
+    });
+    expect(seedStampInfoOf({})).toBeNull();
+    expect(seedStampInfoOf(stampedSeed)).toEqual({
+      doc_type: 'statute-consolidated',
+      consolidation_version: '20260380',
+      content_absent_version: null,
+    });
+  });
+
+  it('seedStampInfoOf surfaces the consolidated-content-absent shell version', () => {
+    expect(
+      seedStampInfoOf({
+        _ingest: {
+          doc_type: 'statute',
+          consolidation_version: null,
+          consolidated_content_absent: { version: '20050045', consolidated_to: '2005-01-28' },
+        },
+      })
+    ).toEqual({ doc_type: 'statute', consolidation_version: null, content_absent_version: '20050045' });
   });
 });
 
@@ -117,8 +272,11 @@ describe('decideRewrite (post-fetch)', () => {
     expect(decideRewrite({ stampedVersion: 'garbage', fetchedVersion: '20260380' })).toBe('refetch_unknown');
   });
 
-  it('rewrites when upstream is OLDER than the stamp (inconsistent — re-stamp settles it)', () => {
-    expect(decideRewrite({ stampedVersion: '20260380', fetchedVersion: '20230239' })).toBe('refetch_unknown');
+  it('REFUSES to rewrite when upstream serves an OLDER expression than the stamp (stale upstream anomaly)', () => {
+    // The stamp PROVES a newer consolidation was served before (fin@latest sits
+    // behind a ~10-min cache, so an older response is a realistic mid-run
+    // occurrence). Rewriting would erase newer text AND its provable stamp.
+    expect(decideRewrite({ stampedVersion: '20260380', fetchedVersion: '20230239' })).toBe('stale_upstream');
   });
 
   it('rewrites when the fetched expression carries no version (original as-enacted path)', () => {

--- a/tests/ingest/fs-atomic.test.ts
+++ b/tests/ingest/fs-atomic.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { writeFileAtomicSync } from '../../scripts/lib/fs-atomic.js';
+
+describe('writeFileAtomicSync', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-atomic-'));
+  });
+
+  it('writes content and leaves no tmp file behind', () => {
+    const target = path.join(dir, 'nested', 'file.json');
+    writeFileAtomicSync(target, '{"a":1}');
+    expect(fs.readFileSync(target, 'utf-8')).toBe('{"a":1}');
+    expect(fs.readdirSync(path.dirname(target))).toEqual(['file.json']);
+  });
+
+  it('replaces an existing file atomically (rename, not truncate-then-write)', () => {
+    const target = path.join(dir, 'file.txt');
+    fs.writeFileSync(target, 'old', 'utf-8');
+    writeFileAtomicSync(target, 'new content');
+    expect(fs.readFileSync(target, 'utf-8')).toBe('new content');
+    expect(fs.readdirSync(dir)).toEqual(['file.txt']);
+  });
+});

--- a/tests/ingest/fs-atomic.test.ts
+++ b/tests/ingest/fs-atomic.test.ts
@@ -26,3 +26,17 @@ describe('writeFileAtomicSync', () => {
     expect(fs.readdirSync(dir)).toEqual(['file.txt']);
   });
 });
+
+describe('orphan tmp cleanup (PR #79 round 3)', () => {
+  it('removes stale tmp orphans from earlier killed processes before writing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-atomic-r3-'));
+    const target = path.join(dir, 'seed.json');
+    // Orphans from two earlier SIGKILLed runs (different pids).
+    fs.writeFileSync(`${target}.tmp-11111`, 'orphan one');
+    fs.writeFileSync(`${target}.tmp-22222`, 'orphan two');
+    writeFileAtomicSync(target, 'fresh content');
+    expect(fs.readFileSync(target, 'utf-8')).toBe('fresh content');
+    const leftovers = fs.readdirSync(dir).filter(f => f.includes('.tmp-'));
+    expect(leftovers).toEqual([]);
+  });
+});

--- a/tests/ingest/ingest-consolidated.test.ts
+++ b/tests/ingest/ingest-consolidated.test.ts
@@ -25,6 +25,15 @@ const consolidatedSwe = fs.readFileSync(
   'utf-8'
 );
 const originalFin = fs.readFileSync(path.join(FIXTURES, 'statute-2018-1050-fin-original.xml'), 'utf-8');
+const repealedFin = fs.readFileSync(
+  path.join(FIXTURES, 'statute-consolidated-1999-523-fin-latest.xml'),
+  'utf-8'
+);
+const contentAbsentShell = fs.readFileSync(
+  path.join(FIXTURES, 'statute-consolidated-2005-45-fin-contentabsent.xml'),
+  'utf-8'
+);
+const original45 = fs.readFileSync(path.join(FIXTURES, 'statute-2005-45-fin-original.xml'), 'utf-8');
 
 describe('parseFinlexXml on a consolidated (multipleVersions) document', () => {
   const parsed = parseFinlexXml(consolidatedFin, '1050/2018');
@@ -70,6 +79,14 @@ describe('ingestFinlexStatute (offline, injected fetch)', () => {
     }) as typeof fetch;
   }
 
+  function baseOpts(): { delayMs: number; cacheDir: string; forensicCacheDir: string } {
+    return {
+      delayMs: 0,
+      cacheDir: path.join(tmpDir, 'cache'),
+      forensicCacheDir: path.join(tmpDir, 'forensic'),
+    };
+  }
+
   it('acquires the newest consolidation and stamps the version identity', async () => {
     const seedPath = path.join(tmpDir, '1050_2018.json');
     const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
@@ -77,8 +94,7 @@ describe('ingestFinlexStatute (offline, injected fetch)', () => {
         'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
         'statute-consolidated/2018/1050/swe@latest': { status: 200, body: consolidatedSwe },
       }),
-      delayMs: 0,
-      cacheDir: path.join(tmpDir, 'cache'),
+      ...baseOpts(),
     });
 
     expect(outcome.written).toBe(true);
@@ -101,6 +117,24 @@ describe('ingestFinlexStatute (offline, injected fetch)', () => {
     expect(sec18a).toBeDefined();
     // Amendment provenance captured from finlex:originalVersionLabel
     expect(sec18a.metadata.amended_by).toBe('27.11.2020/902');
+
+    // Status is a FACT from finlex lifecycle metadata, never a constant.
+    expect(seed.status).toBe('in_force');
+    expect(seed._ingest.status_basis).toBe('finlex_lifecycle_metadata');
+    expect(seed._ingest.lifecycle.is_in_force).toBe(true);
+    // in_force_date from finlex:dateEntryIntoForce, not the enactment date.
+    expect(seed.in_force_date).toBe('2019-01-01');
+
+    // provision_versions claim validity from the CONSOLIDATION's date, not the
+    // original enactment date (an inserted §18a did not exist in 2018).
+    expect(seed.provision_versions[0].valid_from).toBe('2026-05-22');
+
+    // Forensic copies live OUTSIDE the immutable original cache.
+    const cacheDir = path.join(tmpDir, 'cache');
+    const cacheFiles = fs.existsSync(cacheDir) ? fs.readdirSync(cacheDir) : [];
+    expect(cacheFiles.filter(f => f.includes('@'))).toEqual([]);
+    const forensic = fs.readdirSync(path.join(tmpDir, 'forensic'));
+    expect(forensic).toContain('2018_1050_fin@20260380.consolidated.xml');
   });
 
   it('falls back to the original ONLY on a definitive consolidated 404, loudly stamped', async () => {
@@ -112,8 +146,7 @@ describe('ingestFinlexStatute (offline, injected fetch)', () => {
         'statute/2018/1050/fin@': { status: 200, body: originalFin },
         'statute/2018/1050/swe@': { status: 404 },
       }),
-      delayMs: 0,
-      cacheDir: path.join(tmpDir, 'cache'),
+      ...baseOpts(),
     });
 
     expect(outcome.consolidationAbsent).toBe(true);
@@ -123,6 +156,31 @@ describe('ingestFinlexStatute (offline, injected fetch)', () => {
     expect(seed.url).toBe(
       'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute/2018/1050/fin@'
     );
+    // As-enacted originals carry NO lifecycle metadata upstream: the status is
+    // the documented corpus default, stamped as unverified — auditable, never
+    // disguised as a proven fact.
+    expect(seed.status).toBe('in_force');
+    expect(seed._ingest.status_basis).toBe('as_enacted_default_unverified');
+    // As-enacted text: validity claimed from enactment, the only date upstream proves.
+    expect(seed.provision_versions[0].valid_from).toBe('2018-12-05');
+  });
+
+  it('stamps repealed acts as repealed from finlex lifecycle metadata (523/1999, repealed by 1050/2018)', async () => {
+    const seedPath = path.join(tmpDir, '523_1999.json');
+    await ingestFinlexStatute('523/1999', seedPath, {
+      fetchImpl: makeFetch({
+        'statute-consolidated/1999/523/fin@latest': { status: 200, body: repealedFin },
+        'statute-consolidated/1999/523/swe@latest': { status: 404 },
+      }),
+      ...baseOpts(),
+    });
+
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
+    expect(seed.status).toBe('repealed');
+    expect(seed._ingest.status_basis).toBe('finlex_lifecycle_metadata');
+    expect(seed._ingest.lifecycle.is_in_force).toBe(false);
+    expect(seed._ingest.lifecycle.date_in_force_end).toBe('2018-12-31');
+    expect(seed._ingest.lifecycle.repealed_by).toEqual(['1050/2018']);
   });
 
   it('THROWS when both consolidated and original are gone — never writes a hollow seed', async () => {
@@ -133,8 +191,7 @@ describe('ingestFinlexStatute (offline, injected fetch)', () => {
           'statute-consolidated/2018/1050/fin@latest': { status: 404 },
           'statute/2018/1050/fin@': { status: 404 },
         }),
-        delayMs: 0,
-        cacheDir: path.join(tmpDir, 'cache'),
+        ...baseOpts(),
       })
     ).rejects.toThrow(/404|not found/iu);
     expect(fs.existsSync(seedPath)).toBe(false);
@@ -147,34 +204,60 @@ describe('ingestFinlexStatute (offline, injected fetch)', () => {
         fetchImpl: makeFetch({
           'statute-consolidated/2018/1050/fin@latest': { status: 503 },
         }),
-        delayMs: 0,
-        cacheDir: path.join(tmpDir, 'cache'),
+        ...baseOpts(),
         retryBackoffMs: [0, 0, 0],
       })
     ).rejects.toThrow(/503/u);
     expect(fs.existsSync(seedPath)).toBe(false);
   });
 
-  it('skips the rewrite when the stamped version matches upstream (skip_current)', async () => {
+  it('skips the rewrite when BOTH stamped language versions match upstream (skip_current, no Swedish probe)', async () => {
     const seedPath = path.join(tmpDir, '1050_2018.json');
     const opts = {
       fetchImpl: makeFetch({
         'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
         'statute-consolidated/2018/1050/swe@latest': { status: 200, body: consolidatedSwe },
       }),
-      delayMs: 0,
-      cacheDir: path.join(tmpDir, 'cache'),
+      ...baseOpts(),
     };
     await ingestFinlexStatute('1050/2018', seedPath, opts);
     const firstWrite = fs.readFileSync(seedPath, 'utf-8');
 
     const second = await ingestFinlexStatute('1050/2018', seedPath, {
-      ...opts,
+      // Routes deliberately limited to the FINNISH probe: a skip must not
+      // touch the Swedish endpoint (makeFetch throws on unexpected URLs).
+      fetchImpl: makeFetch({
+        'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
+      }),
+      ...baseOpts(),
       existingStampedVersion: '20260380',
+      existingStampedSwedishVersion: '20260380',
     });
     expect(second.written).toBe(false);
     expect(second.decision).toBe('skip_current');
     expect(fs.readFileSync(seedPath, 'utf-8')).toBe(firstWrite);
+  });
+
+  it('does NOT skip when the Finnish version matches but Swedish was previously omitted (the parked-forever hole)', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    // Seed written earlier with Swedish omitted: stamped fin=20260380, no swe.
+    fs.writeFileSync(seedPath, JSON.stringify({ id: '1050/2018', provisions: [{ provision_ref: '1:1', section: '1', content: 'x' }] }), 'utf-8');
+
+    const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl: makeFetch({
+        'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
+        'statute-consolidated/2018/1050/swe@latest': { status: 200, body: consolidatedSwe },
+      }),
+      ...baseOpts(),
+      existingStampedVersion: '20260380',
+      existingStampedSwedishVersion: null,
+    });
+
+    // The Swedish consolidation has caught up — the seed must be completed.
+    expect(outcome.decision).not.toBe('skip_current');
+    expect(outcome.swedish).toBe('consolidated');
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
+    expect(seed._ingest.languages.swe.consolidation_version).toBe('20260380');
   });
 
   it('omits Swedish text when the Swedish consolidation is at a DIFFERENT version (no silently mixed versions)', async () => {
@@ -187,13 +270,208 @@ describe('ingestFinlexStatute (offline, injected fetch)', () => {
         'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
         'statute-consolidated/2018/1050/swe@latest': { status: 200, body: mismatchedSwe },
       }),
-      delayMs: 0,
-      cacheDir: path.join(tmpDir, 'cache'),
+      ...baseOpts(),
     });
 
     expect(outcome.swedish).toBe('omitted_version_mismatch');
     const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
     expect(JSON.stringify(seed.provisions)).not.toContain('content_sv');
     expect(seed._ingest.languages.swe).toBeUndefined();
+  });
+
+  it('falls back EXPLICITLY (stamped) to the original when the consolidation is an empty contentAbsent shell', async () => {
+    const seedPath = path.join(tmpDir, '45_2005.json');
+    const outcome = await ingestFinlexStatute('45/2005', seedPath, {
+      fetchImpl: makeFetch({
+        'statute-consolidated/2005/45/fin@latest': { status: 200, body: contentAbsentShell },
+        'statute/2005/45/fin@': { status: 200, body: original45 },
+        'statute/2005/45/swe@': { status: 404 },
+      }),
+      ...baseOpts(),
+    });
+
+    expect(outcome.contentAbsentFallback).toBe(true);
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
+    // Real text from the as-enacted original — never a hollow seed.
+    expect(seed.provisions.length).toBeGreaterThan(0);
+    expect(seed._ingest.doc_type).toBe('statute');
+    expect(seed.url).toContain('/act/statute/2005/45/fin@');
+    // The shell's existence and version are stamped, not erased.
+    expect(seed._ingest.consolidated_content_absent).toEqual({
+      version: '20050045',
+      consolidated_to: '2005-01-28',
+    });
+    // Status comes from the SHELL's lifecycle metadata (authoritative even
+    // when the body is absent): 45/2005 is in force per finlex:isInForce.
+    expect(seed.status).toBe('in_force');
+    expect(seed._ingest.status_basis).toBe('finlex_lifecycle_metadata');
+    expect(seed.in_force_date).toBe('2005-10-05');
+  });
+
+  it('FAILS LOUD when a document parses to zero provisions without a recognized contentAbsent marker', async () => {
+    const seedPath = path.join(tmpDir, '45_2005.json');
+    const unknownShape = contentAbsentShell.replace(
+      '<hcontainer name="contentAbsent"/>',
+      '<p>unrecognized body shape</p>'
+    );
+    await expect(
+      ingestFinlexStatute('45/2005', seedPath, {
+        fetchImpl: makeFetch({
+          'statute-consolidated/2005/45/fin@latest': { status: 200, body: unknownShape },
+        }),
+        ...baseOpts(),
+      })
+    ).rejects.toThrow(/zero provisions/iu);
+    expect(fs.existsSync(seedPath)).toBe(false);
+  });
+
+  it('NEVER overwrites a seed holding real content when the shell fallback has nothing to offer', async () => {
+    const seedPath = path.join(tmpDir, '45_2005.json');
+    const realContent = JSON.stringify({
+      id: '45/2005',
+      provisions: [{ provision_ref: '1', section: '1', content: 'real statute text' }],
+    });
+    fs.writeFileSync(seedPath, realContent, 'utf-8');
+
+    await expect(
+      ingestFinlexStatute('45/2005', seedPath, {
+        fetchImpl: makeFetch({
+          'statute-consolidated/2005/45/fin@latest': { status: 200, body: contentAbsentShell },
+          'statute/2005/45/fin@': { status: 404 },
+        }),
+        ...baseOpts(),
+      })
+    ).rejects.toThrow();
+    expect(fs.readFileSync(seedPath, 'utf-8')).toBe(realContent);
+  });
+
+  it('retries a 404 on a PREVIOUSLY-consolidated statute and proceeds when it was transient', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    fs.writeFileSync(seedPath, '{"id":"1050/2018","provisions":[{"section":"1","content":"old"}]}', 'utf-8');
+    let finCalls = 0;
+    const fetchImpl = (async (url: unknown) => {
+      const u = String(url);
+      if (u.includes('statute-consolidated/2018/1050/fin@latest')) {
+        finCalls += 1;
+        return finCalls === 1
+          ? new Response('not found', { status: 404 })
+          : new Response(consolidatedFin, { status: 200 });
+      }
+      if (u.includes('statute-consolidated/2018/1050/swe@latest')) {
+        return new Response(consolidatedSwe, { status: 200 });
+      }
+      throw new Error(`Unexpected URL in test: ${u}`);
+    }) as typeof fetch;
+
+    const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl,
+      ...baseOpts(),
+      existingStampedVersion: '20230239',
+    });
+    expect(finCalls).toBe(2);
+    expect(outcome.consolidationAbsent).toBe(false);
+    expect(outcome.decision).toBe('refetch_changed');
+  });
+
+  it('treats a PERSISTENT 404 on a previously-consolidated statute as a loud anomaly, never a silent downgrade', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const before = '{"id":"1050/2018","provisions":[{"section":"1","content":"consolidated text"}]}';
+    fs.writeFileSync(seedPath, before, 'utf-8');
+    let finCalls = 0;
+    const fetchImpl = (async (url: unknown) => {
+      const u = String(url);
+      if (u.includes('statute-consolidated/2018/1050/fin@latest')) {
+        finCalls += 1;
+        return new Response('not found', { status: 404 });
+      }
+      // The as-enacted original IS available — the old code silently downgraded to it.
+      if (u.includes('statute/2018/1050/fin@')) {
+        return new Response(originalFin, { status: 200 });
+      }
+      throw new Error(`Unexpected URL in test: ${u}`);
+    }) as typeof fetch;
+
+    await expect(
+      ingestFinlexStatute('1050/2018', seedPath, {
+        fetchImpl,
+        ...baseOpts(),
+        existingStampedVersion: '20230239',
+      })
+    ).rejects.toThrow(/disappear|downgrade|anomal/iu);
+    expect(finCalls).toBeGreaterThanOrEqual(2);
+    expect(fs.readFileSync(seedPath, 'utf-8')).toBe(before);
+  });
+
+  it('keeps the newer seed when upstream serves an OLDER consolidation than the stamp (stale_upstream)', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const before = '{"id":"1050/2018","provisions":[{"section":"1","content":"newer text"}]}';
+    fs.writeFileSync(seedPath, before, 'utf-8');
+
+    const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl: makeFetch({
+        'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
+      }),
+      ...baseOpts(),
+      existingStampedVersion: '20270001', // stamp PROVES a newer consolidation was served before
+    });
+
+    expect(outcome.decision).toBe('stale_upstream');
+    expect(outcome.written).toBe(false);
+    expect(fs.readFileSync(seedPath, 'utf-8')).toBe(before);
+  });
+
+  it('REJECTS a served body whose identity does not match the requested statute (redirect surprises)', async () => {
+    const seedPath = path.join(tmpDir, '999_2018.json');
+    await expect(
+      ingestFinlexStatute('999/2018', seedPath, {
+        fetchImpl: makeFetch({
+          // Upstream serves the 1050/2018 document for the 999/2018 request.
+          'statute-consolidated/2018/999/fin@latest': { status: 200, body: consolidatedFin },
+        }),
+        ...baseOpts(),
+      })
+    ).rejects.toThrow(/identity|mismatch/iu);
+    expect(fs.existsSync(seedPath)).toBe(false);
+  });
+
+  it('self-heals a corrupt original-XML cache file instead of failing forever (sticky-cache fix)', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    // A truncated/corrupt cache file from an interrupted earlier run.
+    fs.writeFileSync(path.join(cacheDir, '2018_1050_fin.xml'), '<akomaNtoso><act><met', 'utf-8');
+
+    const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl: makeFetch({
+        'statute-consolidated/2018/1050/fin@latest': { status: 404 },
+        'statute-consolidated/2018/1050/swe@latest': { status: 404 },
+        'statute/2018/1050/fin@': { status: 200, body: originalFin },
+        'statute/2018/1050/swe@': { status: 404 },
+      }),
+      ...baseOpts(),
+    });
+
+    expect(outcome.consolidationAbsent).toBe(true);
+    expect(fs.existsSync(seedPath)).toBe(true);
+    // The corrupt cache entry was replaced by the refetched valid document.
+    expect(fs.readFileSync(path.join(cacheDir, '2018_1050_fin.xml'), 'utf-8')).toContain('<identification');
+  });
+
+  it('prunes superseded forensic copies (keep only the version just fetched)', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const forensicDir = path.join(tmpDir, 'forensic');
+    fs.mkdirSync(forensicDir, { recursive: true });
+    fs.writeFileSync(path.join(forensicDir, '2018_1050_fin@20230239.consolidated.xml'), '<old/>', 'utf-8');
+
+    await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl: makeFetch({
+        'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
+        'statute-consolidated/2018/1050/swe@latest': { status: 200, body: consolidatedSwe },
+      }),
+      ...baseOpts(),
+    });
+
+    const copies = fs.readdirSync(forensicDir).filter(f => f.startsWith('2018_1050_fin@'));
+    expect(copies).toEqual(['2018_1050_fin@20260380.consolidated.xml']);
   });
 });

--- a/tests/ingest/ingest-consolidated.test.ts
+++ b/tests/ingest/ingest-consolidated.test.ts
@@ -475,3 +475,178 @@ describe('ingestFinlexStatute (offline, injected fetch)', () => {
     expect(copies).toEqual(['2018_1050_fin@20260380.consolidated.xml']);
   });
 });
+
+describe('round-3 hardening (PR #79 delta review)', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'finlex-r3-test-'));
+  });
+  function makeCountingFetch(
+    routes: Record<string, { status: number; body?: string } | Array<{ status: number; body?: string }>>,
+    counts: Map<string, number>,
+  ): typeof fetch {
+    return (async (url: unknown) => {
+      const u = String(url);
+      for (const [needle, r] of Object.entries(routes)) {
+        if (u.includes(needle)) {
+          const n = (counts.get(needle) ?? 0) + 1;
+          counts.set(needle, n);
+          const resp = Array.isArray(r) ? r[Math.min(n - 1, r.length - 1)] : r;
+          return new Response(resp.body ?? 'not found', { status: resp.status });
+        }
+      }
+      throw new Error(`Unexpected URL in test: ${u}`);
+    }) as typeof fetch;
+  }
+  const opts = () => ({
+    delayMs: 0,
+    cacheDir: path.join(tmpDir, 'cache'),
+    forensicCacheDir: path.join(tmpDir, 'forensic'),
+  });
+
+  it('F1: zero-provision Swedish text is never stamped consolidated', async () => {
+    // Swedish responds with the contentAbsent shell at the MATCHING version:
+    // version equality alone must not stamp swedish='consolidated'.
+    const sweShell = contentAbsentShell
+      .replace(/2005\/45/gu, '2018/1050')
+      .replace(/20050045/gu, '20260380')
+      .replace(/45\/2005/gu, '1050/2018');
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const counts = new Map<string, number>();
+    const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl: makeCountingFetch(
+        {
+          'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
+          'statute-consolidated/2018/1050/swe@latest': { status: 200, body: sweShell },
+        },
+        counts,
+      ),
+      ...opts(),
+    });
+    expect(outcome.written).toBe(true);
+    expect(outcome.swedish).toBe('omitted_content_absent');
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
+    // No Swedish stamp => the both-languages skip_current can never treat
+    // this seed as bilingual-complete.
+    expect(seed._ingest.languages.swe).toBeUndefined();
+  });
+
+  it('F2a: the stamp is read from the existing seed when the caller does not supply it', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    fs.writeFileSync(
+      seedPath,
+      JSON.stringify({ id: '1050/2018', _ingest: { doc_type: 'statute-consolidated', consolidation_version: '20260380' } }),
+    );
+    const counts = new Map<string, number>();
+    // Persistent 404 on the consolidated expression: the on-disk stamp proves
+    // a consolidation existed -> loud anomaly, NEVER a silent downgrade.
+    await expect(
+      ingestFinlexStatute('1050/2018', seedPath, {
+        fetchImpl: makeCountingFetch(
+          { 'statute-consolidated/2018/1050/fin@latest': { status: 404 } },
+          counts,
+        ),
+        ...opts(),
+      }),
+    ).rejects.toThrow(/DISAPPEARED|anomaly/iu);
+  });
+
+  it('F2b: a first 404 on the consolidated expression gets one confirming probe even with no stamp', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const counts = new Map<string, number>();
+    const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl: makeCountingFetch(
+        {
+          // transient 404, then the real consolidation on the confirm probe
+          'statute-consolidated/2018/1050/fin@latest': [
+            { status: 404 },
+            { status: 200, body: consolidatedFin },
+          ],
+          'statute-consolidated/2018/1050/swe@latest': { status: 200, body: consolidatedSwe },
+        },
+        counts,
+      ),
+      ...opts(),
+    });
+    expect(counts.get('statute-consolidated/2018/1050/fin@latest')).toBe(2);
+    expect(outcome.consolidationAbsent).toBe(false);
+  });
+
+  it('F3: a body-torn as-enacted cache file is discarded and refetched', async () => {
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    // Head intact (identification parses), body torn at 60%.
+    const torn = original45.slice(0, Math.floor(original45.length * 0.6));
+    fs.writeFileSync(path.join(cacheDir, '2005_45_fin.xml'), torn);
+    const counts = new Map<string, number>();
+    const outcome = await ingestFinlexStatute('45/2005', path.join(tmpDir, '45_2005.json'), {
+      fetchImpl: makeCountingFetch(
+        {
+          'statute-consolidated/2005/45/fin@latest': { status: 200, body: contentAbsentShell },
+          'statute/2005/45/fin@': { status: 200, body: original45 },
+          'statute-consolidated/2005/45/swe@latest': { status: 404 },
+          'statute/2005/45/swe@': { status: 404 },
+        },
+        counts,
+      ),
+      ...opts(),
+    });
+    expect(outcome.written).toBe(true);
+    // The torn cache must NOT have been trusted: the as-enacted expression
+    // was refetched over the network.
+    expect(counts.get('statute/2005/45/fin@')).toBeGreaterThanOrEqual(1);
+  });
+
+  it('F4: the forensic prune keeps the NEWEST version, not the just-fetched one', async () => {
+    const forensic = path.join(tmpDir, 'forensic');
+    fs.mkdirSync(forensic, { recursive: true });
+    // A NEWER forensic copy exists (the XML the kept seed was built from).
+    fs.writeFileSync(path.join(forensic, '2018_1050_fin@20270001.consolidated.xml'), '<newer/>');
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    fs.writeFileSync(seedPath, JSON.stringify({ id: '1050/2018' }));
+    const counts = new Map<string, number>();
+    // Upstream serves the OLDER 20260380 while the stamp says 20270001:
+    // stale_upstream path — the newer audit copy must survive.
+    await ingestFinlexStatute('1050/2018', seedPath, {
+      existingStampedVersion: '20270001',
+      fetchImpl: makeCountingFetch(
+        { 'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin } },
+        counts,
+      ),
+      ...opts(),
+    });
+    expect(fs.existsSync(path.join(forensic, '2018_1050_fin@20270001.consolidated.xml'))).toBe(true);
+  });
+
+  it('F7: repealed statutes carry the repeal date in the description (build-db extractor convention)', async () => {
+    const seedPath = path.join(tmpDir, '523_1999.json');
+    const counts = new Map<string, number>();
+    await ingestFinlexStatute('523/1999', seedPath, {
+      fetchImpl: makeCountingFetch(
+        {
+          'statute-consolidated/1999/523/fin@latest': { status: 200, body: repealedFin },
+          'statute-consolidated/1999/523/swe@latest': { status: 404 },
+          'statute/1999/523/swe@': { status: 404 },
+        },
+        counts,
+      ),
+      ...opts(),
+    });
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
+    expect(seed.status).toBe('repealed');
+    expect(seed.description).toMatch(/Kumottu \d{4}-\d{2}-\d{2}/u);
+  });
+});
+
+describe('contentAbsent detection is structural (round 3, F8)', () => {
+  it('does not flag a document whose marker sits outside an otherwise substantive body', () => {
+    // A future shape gap that parses 0 provisions must FAIL LOUD, not slide
+    // into the contentAbsent fallback because a marker matched anywhere.
+    const xml = contentAbsentShell.replace(
+      '<hcontainer name="contentAbsent"/>',
+      '<unknownVocab>real text the extractor cannot read yet</unknownVocab>',
+    ).replace('</meta>', '<note><hcontainer name="contentAbsent"/></note></meta>');
+    const parsed = parseFinlexXml(xml, '45/2005');
+    expect(parsed.contentAbsent).toBe(false);
+  });
+});

--- a/tests/ingest/ingest-consolidated.test.ts
+++ b/tests/ingest/ingest-consolidated.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Acquisition repair tests (issue #78): the ingest must serve the CURRENT
+ * consolidation (statute-consolidated/{y}/{n}/fin@latest), never pin to the
+ * original as-enacted expression (statute/{y}/{n}/fin@ = alkup).
+ *
+ * Oracle (real upstream data, captured 2026-06-10): Tietosuojalaki 1050/2018
+ * consolidation 20260380 contains §18a (inserted by 902/2020) and the
+ * 808/2019-based §25 — none of which exist in the as-enacted text the old
+ * pipeline fetched.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { parseFinlexXml, ingestFinlexStatute } from '../../scripts/ingest-finlex.js';
+
+const FIXTURES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../fixtures/finlex');
+const consolidatedFin = fs.readFileSync(
+  path.join(FIXTURES, 'statute-consolidated-2018-1050-fin-latest.xml'),
+  'utf-8'
+);
+const consolidatedSwe = fs.readFileSync(
+  path.join(FIXTURES, 'statute-consolidated-2018-1050-swe-latest.xml'),
+  'utf-8'
+);
+const originalFin = fs.readFileSync(path.join(FIXTURES, 'statute-2018-1050-fin-original.xml'), 'utf-8');
+
+describe('parseFinlexXml on a consolidated (multipleVersions) document', () => {
+  const parsed = parseFinlexXml(consolidatedFin, '1050/2018');
+
+  it('extracts the inserted §18a (added by 902/2020, absent from the as-enacted text)', () => {
+    const sec18a = parsed.provisions.find(p => p.section === '18 a');
+    expect(sec18a).toBeDefined();
+    expect(sec18a?.content).toContain('61 artiklassa');
+  });
+
+  it('extracts the amended §25 (808/2019 reference replaced the 586/1996 one)', () => {
+    const sec25 = parsed.provisions.find(p => p.section === '25' && p.chapter === '4');
+    expect(sec25).toBeDefined();
+    expect(sec25?.content).toContain('808/2019');
+    expect(sec25?.content).not.toContain('586/1996');
+  });
+
+  it('keeps every original section plus both inserted ones (38 + §18a + §36a = 40, no duplicates)', () => {
+    expect(parsed.provisions).toHaveLength(40);
+    const sec36a = parsed.provisions.find(p => p.section === '36 a');
+    expect(sec36a).toBeDefined(); // inserted by 380/2026 — the newest amendment
+    const refs = parsed.provisions.map(p => `${p.chapter ?? ''}:${p.section}`);
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+});
+
+describe('ingestFinlexStatute (offline, injected fetch)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'finlex-ingest-test-'));
+  });
+
+  function makeFetch(routes: Record<string, { status: number; body?: string }>): typeof fetch {
+    return (async (url: unknown) => {
+      const u = String(url);
+      for (const [needle, r] of Object.entries(routes)) {
+        if (u.includes(needle)) {
+          return new Response(r.body ?? 'not found', { status: r.status });
+        }
+      }
+      throw new Error(`Unexpected URL in test: ${u}`);
+    }) as typeof fetch;
+  }
+
+  it('acquires the newest consolidation and stamps the version identity', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl: makeFetch({
+        'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
+        'statute-consolidated/2018/1050/swe@latest': { status: 200, body: consolidatedSwe },
+      }),
+      delayMs: 0,
+      cacheDir: path.join(tmpDir, 'cache'),
+    });
+
+    expect(outcome.written).toBe(true);
+    expect(outcome.consolidationAbsent).toBe(false);
+
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
+    // url is the version-PINNED expression, never an ambiguous-version URL
+    expect(seed.url).toBe(
+      'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute-consolidated/2018/1050/fin@20260380'
+    );
+    expect(seed._ingest.doc_type).toBe('statute-consolidated');
+    expect(seed._ingest.consolidation_version).toBe('20260380');
+    expect(seed._ingest.consolidated_to).toBe('2026-05-22');
+    expect(seed._ingest.retrieved_at).toMatch(/^\d{4}-\d{2}-\d{2}T/u);
+    expect(seed._ingest.languages.fin.consolidation_version).toBe('20260380');
+    expect(seed._ingest.languages.swe.consolidation_version).toBe('20260380');
+
+    // The amendment content is in the seed (the staleness oracle)
+    const sec18a = seed.provisions.find((p: { section: string }) => p.section === '18 a');
+    expect(sec18a).toBeDefined();
+    // Amendment provenance captured from finlex:originalVersionLabel
+    expect(sec18a.metadata.amended_by).toBe('27.11.2020/902');
+  });
+
+  it('falls back to the original ONLY on a definitive consolidated 404, loudly stamped', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl: makeFetch({
+        'statute-consolidated/2018/1050/fin@latest': { status: 404 },
+        'statute-consolidated/2018/1050/swe@latest': { status: 404 },
+        'statute/2018/1050/fin@': { status: 200, body: originalFin },
+        'statute/2018/1050/swe@': { status: 404 },
+      }),
+      delayMs: 0,
+      cacheDir: path.join(tmpDir, 'cache'),
+    });
+
+    expect(outcome.consolidationAbsent).toBe(true);
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
+    expect(seed._ingest.doc_type).toBe('statute');
+    expect(seed._ingest.consolidation_version).toBeNull();
+    expect(seed.url).toBe(
+      'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute/2018/1050/fin@'
+    );
+  });
+
+  it('THROWS when both consolidated and original are gone — never writes a hollow seed', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    await expect(
+      ingestFinlexStatute('1050/2018', seedPath, {
+        fetchImpl: makeFetch({
+          'statute-consolidated/2018/1050/fin@latest': { status: 404 },
+          'statute/2018/1050/fin@': { status: 404 },
+        }),
+        delayMs: 0,
+        cacheDir: path.join(tmpDir, 'cache'),
+      })
+    ).rejects.toThrow(/404|not found/iu);
+    expect(fs.existsSync(seedPath)).toBe(false);
+  });
+
+  it('propagates transient failures instead of treating them as gone', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    await expect(
+      ingestFinlexStatute('1050/2018', seedPath, {
+        fetchImpl: makeFetch({
+          'statute-consolidated/2018/1050/fin@latest': { status: 503 },
+        }),
+        delayMs: 0,
+        cacheDir: path.join(tmpDir, 'cache'),
+        retryBackoffMs: [0, 0, 0],
+      })
+    ).rejects.toThrow(/503/u);
+    expect(fs.existsSync(seedPath)).toBe(false);
+  });
+
+  it('skips the rewrite when the stamped version matches upstream (skip_current)', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const opts = {
+      fetchImpl: makeFetch({
+        'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
+        'statute-consolidated/2018/1050/swe@latest': { status: 200, body: consolidatedSwe },
+      }),
+      delayMs: 0,
+      cacheDir: path.join(tmpDir, 'cache'),
+    };
+    await ingestFinlexStatute('1050/2018', seedPath, opts);
+    const firstWrite = fs.readFileSync(seedPath, 'utf-8');
+
+    const second = await ingestFinlexStatute('1050/2018', seedPath, {
+      ...opts,
+      existingStampedVersion: '20260380',
+    });
+    expect(second.written).toBe(false);
+    expect(second.decision).toBe('skip_current');
+    expect(fs.readFileSync(seedPath, 'utf-8')).toBe(firstWrite);
+  });
+
+  it('omits Swedish text when the Swedish consolidation is at a DIFFERENT version (no silently mixed versions)', async () => {
+    const seedPath = path.join(tmpDir, '1050_2018.json');
+    const mismatchedSwe = consolidatedSwe
+      .replace(/20260380/gu, '20230239')
+      .replace(/2026-05-22/gu, '2023-02-16');
+    const outcome = await ingestFinlexStatute('1050/2018', seedPath, {
+      fetchImpl: makeFetch({
+        'statute-consolidated/2018/1050/fin@latest': { status: 200, body: consolidatedFin },
+        'statute-consolidated/2018/1050/swe@latest': { status: 200, body: mismatchedSwe },
+      }),
+      delayMs: 0,
+      cacheDir: path.join(tmpDir, 'cache'),
+    });
+
+    expect(outcome.swedish).toBe('omitted_version_mismatch');
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8'));
+    expect(JSON.stringify(seed.provisions)).not.toContain('content_sv');
+    expect(seed._ingest.languages.swe).toBeUndefined();
+  });
+});

--- a/tests/ingest/legacy-guard.test.ts
+++ b/tests/ingest/legacy-guard.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Legacy Swedish-template writers guard (PR #79 round-2, FORCE_LEGACY_INGEST
+ * pattern): auto-ingest-all-statutes.ts and ingest-relevant-laws.ts import
+ * the Riksdagen (SWEDISH parliament) ingest and write UNSTAMPED seeds
+ * straight into data/seed/, bypassing the version-stamped Finlex acquisition.
+ * They must refuse to run unless explicitly forced.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+function runScript(script: string): { status: number | null; stderr: string } {
+  const env = { ...process.env };
+  delete env.FORCE_LEGACY_INGEST;
+  const result = spawnSync('node', ['--import', 'tsx', script, '--dry-run'], {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf-8',
+    timeout: 60_000,
+  });
+  return { status: result.status, stderr: result.stderr };
+}
+
+describe('legacy Riksdagen seed writers refuse to run without FORCE_LEGACY_INGEST', () => {
+  it('auto-ingest-all-statutes.ts exits non-zero with an explanation', () => {
+    const { status, stderr } = runScript('scripts/auto-ingest-all-statutes.ts');
+    expect(status).toBe(2);
+    expect(stderr).toContain('FORCE_LEGACY_INGEST');
+    expect(stderr).toMatch(/legacy/iu);
+  }, 60_000);
+
+  it('ingest-relevant-laws.ts exits non-zero with an explanation', () => {
+    const { status, stderr } = runScript('scripts/ingest-relevant-laws.ts');
+    expect(status).toBe(2);
+    expect(stderr).toContain('FORCE_LEGACY_INGEST');
+  }, 60_000);
+});

--- a/tests/ingest/seed-candidates.test.ts
+++ b/tests/ingest/seed-candidates.test.ts
@@ -1,0 +1,69 @@
+/**
+ * --seeds-only candidate derivation (issue #78 repair run scoping):
+ * a refresh sweep must walk the EXISTING corpus, not the remote catalogue —
+ * otherwise a "refresh" silently expands the corpus with every statute Finlex
+ * lists. Candidates come from data/seed/*.json; the historical fetch token
+ * (e.g. '39-001') is recovered from the stored expression URL when present.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { deriveSeedCandidates } from '../../scripts/ingest-finlex-bulk.js';
+
+describe('deriveSeedCandidates', () => {
+  let seedDir: string;
+
+  beforeEach(() => {
+    seedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'finlex-seeds-'));
+  });
+
+  function writeSeed(name: string, content: unknown): void {
+    fs.writeFileSync(path.join(seedDir, name), JSON.stringify(content), 'utf-8');
+  }
+
+  it('derives candidates from seed filenames and recovers fetch tokens from URLs', () => {
+    writeSeed('1050_2018.json', {
+      id: '1050/2018',
+      url: 'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute-consolidated/2018/1050/fin@20260380',
+    });
+    writeSeed('39_1889.json', {
+      id: '39/1889',
+      url: 'https://opendata.finlex.fi/finlex/avoindata/v1/akn/fi/act/statute/1889/39-001/fin@',
+    });
+    // legacy hand-made seed with a www.finlex.fi URL: token falls back to the number
+    writeSeed('434_2003.json', {
+      id: '434/2003',
+      url: 'https://www.finlex.fi/fi/laki/alkup/2003/20030434',
+    });
+
+    const candidates = deriveSeedCandidates(seedDir);
+    const byId = new Map(candidates.map(c => [c.canonical_id, c]));
+
+    expect(byId.get('1050/2018')?.number_token).toBe('1050');
+    expect(byId.get('1050/2018')?.year).toBe('2018');
+    expect(byId.get('39/1889')?.number_token).toBe('39-001');
+    expect(byId.get('434/2003')?.number_token).toBe('434');
+    expect(candidates).toHaveLength(3);
+  });
+
+  it('ignores non-statute seed artifacts', () => {
+    writeSeed('1050_2018.json', { id: '1050/2018' });
+    writeSeed('_finlex-statutes-manifest.json', { count: 0 });
+    writeSeed('_cross_references.json', []);
+    writeSeed('eu-references.json', { eu_documents: [] });
+
+    const candidates = deriveSeedCandidates(seedDir);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].canonical_id).toBe('1050/2018');
+  });
+
+  it('sorts candidates deterministically (year, then number)', () => {
+    writeSeed('1000_2007.json', { id: '1000/2007' });
+    writeSeed('9_2007.json', { id: '9/2007' });
+    writeSeed('100_2005.json', { id: '100/2005' });
+
+    const ids = deriveSeedCandidates(seedDir).map(c => c.canonical_id);
+    expect(ids).toEqual(['100/2005', '9/2007', '1000/2007']);
+  });
+});


### PR DESCRIPTION
Fixes #78 — Finnish manifestation of the dutch-law-mcp#119 defect class (corpus pinned to original-as-enacted text instead of the current consolidation).

## fin@ semantics — resolved with evidence

**Verdict: `act/statute/{y}/{n}/fin@` serves the ORIGINAL as-enacted text (alkup), not the current consolidation.** The whole bulk pipeline (`scripts/ingest-finlex.ts:516`, `ingest-finlex-bulk.ts`) fetched exactly that URL.

Evidence (live probes, 2026-06-10 — the audit's 403 `MissingAuthenticationTokenException` was a path artifact; statute endpoints are anonymous):

1. `GET .../act/statute/2018/1050/fin@` → `<act contains="originalVersion">`, `FRBRalias name="eli" value="http://data.finlex.fi/eli/sd/2018/1050/alkup"` (**alkup** = as-enacted). Captured as test fixture `tests/fixtures/finlex/statute-2018-1050-fin-original.xml`.
2. Consolidations live under a **different document type**: `act/statute-consolidated/{y}/{n}/{lang}@{VER}`, ELI alias `.../ajantasa`. `VER` is `YYYYNNNN` = year + zero-padded number of the newest amending statute incorporated (e.g. `20260380` = up to 380/2026), carried in `FRBRversionNumber`, with `FRBRdate name="dateConsolidated"`.
3. **A bare `@` on the consolidated doctype resolves to the OLDEST expression** (verified: `statute-consolidated/2018/1050/fin@` returned the enactment-dated consolidation `20181050` even though `20230239` and `20260380` exist). The work-level expression list paginates at `limit<=4` and silently truncates.
4. The OpenAPI spec (`https://opendata.finlex.fi/v3/api-docs`) documents the safe token: *"Ajallinen versio voi olla 'latest', jolloin palautettu versio on uusin"* — `fin@latest` returns the newest version (~10 min cache). Verified live for 1050/2018 (→ `20260380`, ajantasa 2026-05-22), 738/2002 (→ `20250987`), 434/2003 (→ `20250541`).

**Oracle (the issue's pre-sweep screen):** the prod seed for Tietosuojalaki 1050/2018 was missing amendments 808/2019, 869/2020, **902/2020 (inserted §18a)**, 1101/2022, 239/2023 (§23(2) repealed), 1225/2023 and **380/2026 (inserted §36a, in force 2026-05-22)**. The repaired seed contains all of them; the test fixture's 2021-01-01 expectation corresponds to the real 869/2020 §25 rewrite.

## Blast radius

**Whole corpus.** Census of `data/seed/`: 2,050 seeds with `opendata .../statute/.../fin@` URLs + 3 hand-made seeds with `www.finlex.fi/fi/laki/alkup/...` URLs = **2,053 of 2,053 statute seeds acquired from as-enacted expressions**. Every statute amended since enactment carried stale text (e.g. Hallintolaki 434/2003: 71 as-enacted provisions → 89 current). Statutes never amended were coincidentally correct.

## The fix (port of dutch-law-mcp #117/#120)

- **`scripts/lib/finlex-version.ts`** — FRBR version-identity parsing (expression URI, `FRBRversionNumber`, `dateConsolidated`, ELI); `assertCurrentConsolidation` refuses to stamp alkup as current; version-keyed `decideFetch`/`decideRewrite` with **unconditional self-heal for unstamped (pre-fix) seeds**.
- **`scripts/lib/finlex-http.ts`** — transient≠gone: 5xx/429/network retry with backoff then THROW; 404 returned as a finding. ≥2s politeness floor for all Finlex requests (was 250–300ms).
- **`scripts/ingest-finlex.ts`** — acquires `statute-consolidated/.../fin@latest`; the original is used only on a **definitive consolidated 404**, loudly logged and stamped (`_ingest.doc_type: "statute"`, enumerated in the run report). Seeds carry `_ingest` version identity; `url` is now the version-pinned expression. Swedish text is included only at the **same** consolidation version (mismatch ⇒ omitted loudly — never silently mixed versions). Consolidated XML is never read from a version-blind cache. Per-provision `metadata.amended_by` from `finlex:originalVersionLabel`.
- **`scripts/ingest-finlex-bulk.ts`** — `--refresh` (version-keyed sweep) + `--seeds-only` (walk the existing corpus; list-driven candidates would silently expand it). Report enumerates `consolidation_absent` and omitted-Swedish statutes; failures keep the non-zero exit; 429 aborts the run.
- **`scripts/check-updates.ts`** — now pages the statute-CONSOLIDATED list and compares newest version tokens vs seed stamps. The old original-list status check was structurally blind to amendments (original-list entries do not change when a statute is amended).
- **`sources.yml`** — rebuild contract `runnable: true` (verified on this branch: lint + tests + `build:db` → 2,053 docs / 15,710 provisions). Supersedes the fan-out's `runnable:false` draft (local-only commit `55d28cd`): the "corrupted seed data" it flagged is uncommitted chassis-migration WIP in the main working tree, not the committed corpus.

**Tests: 36 new** (`tests/ingest/`: version identity, refresh policy, retry discipline, consolidated parsing incl. inserted §18a/§36a, offline end-to-end ingest with injected fetch, seeds-only candidates) against real captured API fixtures. Full suite: **203 passed / 31 skipped**, lint clean. (Contract tests skip against the committed DB stub by design; they passed against a freshly built DB.)

## Acquisition run (in progress at PR-open time)

Full corpus repair running on the PR branch's code:

```
nohup npx tsx scripts/ingest-finlex-bulk.ts --refresh --seeds-only > /tmp/finlex-refresh-78.log 2>&1 &
```

- Host: dev workstation, worktree `/home/ansvar/Projects/Finnish-law-mcp/.worktrees/fix-version-pin-78`
- Log: `/tmp/finlex-refresh-78.log`; report: `reports/ingest/finlex-bulk-latest.json`
- ~2,053 statutes × ≥2 polite requests ≈ 3–4 h.
- **Completion criteria:** process exits 0; report shows `failed: 0` (or enumerated failures triaged); refreshed seeds committed to this branch as a follow-up data commit; `npm run build:db` green; spot-check `1050/2018` §18a/§36a, `434/2003` provision count ≥ 89.
- Live smoke (already run): 3 statutes inline — stamped seeds verify-then-skip (`skip_current`, zero churn); 21/2005 has no consolidated doc upstream → as-enacted acquired + enumerated.

## Not in scope / known limitations

- `provision_versions.valid_from` still uses the enactment date (pre-existing behavior). Correct per-provision validity windows need the full version history; `metadata.amended_by` now carries the amending-statute label as a first step.
- `status: 'in_force'` is still hardcoded for ingested statutes (pre-existing; repealed statutes upstream are a separate issue).
- Rikoslaki 39/1889 is not in the seed corpus (never was); `statute-consolidated/1889/39/fin@latest` 404s — token variant (`39-001`) handling exists but the statute remains unseeded.
- Do NOT deploy: supervisor handles review, merge, validation, deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
